### PR TITLE
Fixed build settings for UAPhonegapSample when building for Release

### DIFF
--- a/ios-sample/UAPhonegapSample.xcodeproj/project.pbxproj
+++ b/ios-sample/UAPhonegapSample.xcodeproj/project.pbxproj
@@ -529,8 +529,6 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/Airship\"",
-					"\"$(SRCROOT)/../../dev-ios-library/Airship\"",
-					"\"$(SRCROOT)/../../../Library/Developer/Xcode/DerivedData/AirshipLib-drxxzexkdjzwtzdbobeowgblzgsd/Build/Products/Debug-iphoneos\"",
 				);
 				OTHER_CFLAGS = "-DDEBUG";
 				PRODUCT_NAME = UAPhoneGapSample;
@@ -563,8 +561,6 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/Airship\"",
-					"\"$(SRCROOT)/../../dev-ios-library/Airship\"",
-					"\"$(SRCROOT)/../../../Library/Developer/Xcode/DerivedData/AirshipLib-drxxzexkdjzwtzdbobeowgblzgsd/Build/Products/Debug-iphoneos\"",
 				);
 				OTHER_CFLAGS = "-DDEBUG";
 				PRODUCT_NAME = UAPhoneGapSample;


### PR DESCRIPTION
There were two separate settings for Debug and Release builds, only one was correct. I replaced the two with a single setting. 
