### PR TITLE
Correct time while setting Quiet Time.

### DIFF
--- a/ios-sample/UAPhonegapSample/Plugins/PushNotificationPlugin/PushNotificationPlugin.m
+++ b/ios-sample/UAPhonegapSample/Plugins/PushNotificationPlugin/PushNotificationPlugin.m
@@ -1,4 +1,3 @@
-
 #import "PushNotificationPlugin.h"
 #import "UAPush.h"
 #import "UAirship.h"
@@ -470,8 +469,8 @@ typedef void (^UACordovaVoidCallbackBlock)(NSArray *args);
         NSDate *endDate;
 
         NSCalendar *gregorian = [[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar] autorelease];
-        NSDateComponents *startComponents = [gregorian components:NSYearCalendarUnit fromDate:[NSDate date]];
-        NSDateComponents *endComponents = [gregorian components:NSYearCalendarUnit fromDate:[NSDate date]];
+        NSDateComponents *startComponents = [[gregorian components:NSYearCalendarUnit fromDate:[NSDate date]] autorelease];
+        NSDateComponents *endComponents = [[gregorian components:NSYearCalendarUnit fromDate:[NSDate date]] autorelease];
 
         startComponents.hour = [startHr intValue];
         startComponents.minute =[startMin intValue];


### PR DESCRIPTION
Avoiding to set the year in NSDateComponents results in time being adjusted pre-PST.
Example: Setting the quiet time start to 06:00 actually gives 05:54:14 for me.
See: http://stackoverflow.com/questions/13596358/setting-nsdatecomponents-results-in-incorrect-nsdate
