### PR TITLE
The 'push' event executes the callback even when the app is in the background.

### DIFF
--- a/ios-sample/UAPhonegapSample/Plugins/PushNotificationPlugin/PushNotificationPlugin.m
+++ b/ios-sample/UAPhonegapSample/Plugins/PushNotificationPlugin/PushNotificationPlugin.m
@@ -547,7 +547,9 @@ typedef void (^UACordovaVoidCallbackBlock)(NSArray *args);
     NSString *alert = [self alertForUserInfo:userInfo];
     NSMutableDictionary *extras = [self extrasForUserInfo:userInfo];
 
-    [self raisePush:alert withExtras:extras];
+    
+    if (application.applicationState == UIApplicationStateActive)
+        [self raisePush:alert withExtras:extras];
 }
 
 #pragma mark Other stuff


### PR DESCRIPTION
When the app is running in the background (eg. it is visible in the multitasking bar) and receives a notification, the OS alert box pops up. If the user decides to launch the app, push.registerEvent('push', function (push) {}); is called (due to raisePush call in didReceiveRemoteNotification). The 'push' event that is registered should only execute the callback when a push is received while the application is running and not while it is in the background.
