### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,7 @@ See [Instrumenting Android Analytics](http://docs.urbanairship.com/build/android
 to get proper analytics.  
 See [Instrumenting Android Analytics](http://docs.urbanairship.com/build/android_features.html#setting-up-analytics-minor-assembly-required).
 
-1. Copy www/PushNotification.js into the project's www directory
-
-1. Require the PushNotification module `var PushNotification = require('<Path to PushNotification.js>')`
+1. Require the PushNotification module `var PushNotification = cordova.require('<Path to PushNotification.js>')`
 
 ## Example
 A full example can be found in Examples.  To run it, copy the files:


### PR DESCRIPTION
1. Copy www/PushNotification.js into the project's www directory

is not needed, PushNotification.js is located at www/plugins/com.urbanairship.phonegap.PushNotification/www/PushNotification.js and this file is called by cordova_plugin.js
1. Require the PushNotification module `var PushNotification = require('<Path to PushNotification.js>')`

returns an error of 'require is not defined', but works fine with cordova.require.  Not quite sure if this was changed in a updated version of Cordova
1. Require the PushNotification module `var PushNotification = cordova.require('<Path to PushNotification.js>')`
