### PR TITLE
Improve accept rate for push notifications permissions dialog

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,7 +26,7 @@
         <config-file target="res/xml/config.xml" parent="/widget">
             <feature name="PushNotificationPlugin">
                 <param name="android-package" value="com.urbanairship.phonegap.PushNotificationPlugin"/>
-                <param name="onload" value="false" />
+                <param name="onload" value="true" />
             </feature>
         </config-file>
 


### PR DESCRIPTION
On iOS the permissions dialog is shown immediately, when the user opens the app for the first time. This causes many to deny permission to send push notifications.

By deferring the prompt until the app have described the utility of push messages the users are more likely to accept (and you will make more money, since more push notifications will be sent).

My proposed change adjusts the onload property. There may be other ways to achieve the same result too, such as launching the plugin but not actually show the prompt (until called for via the js api).
