### PR TITLE
Remove the need to do so many manual steps on 'phonegap plugin add'

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,8 @@ A migration guide for newer releases of the plugin can be found [here](MIGRATION
         <preference name="com.urbanairship.gcm_sender" value="GCM_SENDER_ID" />
 
 
-5. For iOS; manually install the localized strings to their respective folders. For example; `src/ios/Airship/UI/Default/Common/Resources/de.lproj/UAInteractiveNotifications.strings` will need to be moved to your `platforms/ios/HelloWorld/Resources/de.lproj/` folder. This will need to be completed for all files in the `src/ios/Airship/UI/Default/Common/Resources/` folders. 
-
-6. If your app supports Android API < 14, then you have to manually instrument any Android Activities to have proper analytics.
+5. If your app supports Android API < 14, then you have to manually instrument any Android Activities to have proper analytics.
 See [Instrumenting Android Analytics](http://docs.urbanairship.com/build/android_features.html#setting-up-analytics-minor-assembly-required). 
-
-7. Due to bug https://code.google.com/p/android/issues/detail?id=23271 and https://issues.apache.org/jira/browse/CB-7675, the custom_rules.xml file in the root of android platform project must be deleted.
 
 #### iOS manual installation (unnecessary if installed automatically)
 1. Add src/ios/PushNotificationPlugin to your project

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,6 +22,8 @@
 
     <!-- android -->
     <platform name="android">
+
+        <hook type="after_prepare" src="scripts/remove_files.js" />
        
         <config-file target="res/xml/config.xml" parent="/widget">
             <feature name="PushNotificationPlugin">
@@ -141,6 +143,9 @@
     
     <!-- ios -->
     <platform name="ios">
+        
+        <hook type="after_prepare" src="scripts/copy_resources.js" />
+        
         <config-file target="config.xml" parent="/widget">
              <feature name="PushNotificationPlugin">
                 <param name="ios-package" value="PushNotificationPlugin" />

--- a/scripts/copy_resources.js
+++ b/scripts/copy_resources.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function (context) {    
+    var cordova_util = context.requireCordovaModule('cordova-lib/src/cordova/util');
+    var projectRoot = cordova_util.isCordova(process.cwd());
+    var projectXml = cordova_util.projectConfig(projectRoot);
+    var ConfigParser = context.requireCordovaModule ('cordova-lib/src/ConfigParser/ConfigParser');
+    var projectConfig = new ConfigParser(projectXml);
+    var projName = projectConfig.name();
+    console.log(projName);
+
+    var filestocopy = {
+    ///////////////////////////
+    //          iOS
+    ///////////////////////////
+        ios : [
+            {
+                "plugins/com.urbanairship.phonegap.PushNotification/src/ios/Airship/UI/Default/Common/Resources": "platforms/ios/" + projName
+            }
+        ]
+    };
+
+    function copyResources() {
+        // no need to configure below
+        var platforms = fs.readdirSync('platforms');
+
+        for(var i in platforms) {
+            var platform = platforms[i];
+
+            if (filestocopy[platform] == undefined) {
+                continue;
+            }
+
+            filestocopy[platform].forEach(function(obj) {
+                Object.keys(obj).forEach(function(srcfile) {
+                    var destfile = obj[srcfile];
+
+                    console.log('Copying ' + srcfile + ' to ' + destfile);
+
+                    function copyFileSync( source, target ) {
+
+                        var targetFile = target;
+
+                        //if target is a directory a new file with the same name will be created
+                        if ( fs.existsSync( target ) ) {
+                            if ( fs.lstatSync( target ).isDirectory() ) {
+                                targetFile = path.join( target, path.basename( source ) );
+                            }
+                        }
+
+                        fs.createReadStream( source ).pipe( fs.createWriteStream( targetFile ) );
+                    }
+
+                    function copyFolderRecursiveSync( source, target ) {
+                        var files = [];
+
+                        //check if folder needs to be created or integrated
+                        var targetFolder = path.join( target, path.basename( source ) );
+                        console.log(targetFolder);
+                        if ( !fs.existsSync( targetFolder ) ) {
+                            fs.mkdirSync( targetFolder );
+                        }
+
+                        //copy
+                        if ( fs.lstatSync( source ).isDirectory() ) {
+                            files = fs.readdirSync( source );
+                            files.forEach( function ( file ) {
+                                var curSource = path.join( source, file );
+                                if ( fs.lstatSync( curSource ).isDirectory() ) {
+                                    copyFolderRecursiveSync( curSource, targetFolder );
+                                } else {
+                                    copyFileSync( curSource, targetFolder );
+                                }
+                            } );
+                        }
+                    }            
+
+                    copyFolderRecursiveSync(srcfile, destfile);
+                });
+            });
+        }
+    };
+
+    copyResources();
+};
+

--- a/scripts/remove_files.js
+++ b/scripts/remove_files.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+//
+// This hook removes files the appropriate platform specific location
+
+var filestoremove = {
+///////////////////////////
+//          ANDROID
+///////////////////////////
+    android: [
+        "platforms/android/custom_rules.xml"
+    ]
+};
+
+var fs = require('fs');
+var path = require('path');
+
+// no need to configure below
+var platforms = fs.readdirSync('platforms');
+
+for(var i in platforms) {
+    var platform = platforms[i];
+
+    if (filestoremove[platform] == undefined) {
+        continue;
+    }
+
+    filestoremove[platform].forEach(function(srcfile) {
+        if (fs.existsSync(srcfile)) {
+            fs.unlinkSync(srcfile)
+            console.log('Removing ' + srcfile);
+        }
+    });
+};


### PR DESCRIPTION
Remove need to manually delete custom_rules.xml
Copy resources for iOS
Execute hook on build and run
Don't try to unlink a file that doesn't exist