### PR TITLE
Update cordova-plugin-device dependency id

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,7 @@
       <engine name="cordova" version=">=3.4.0" />
     </engines>
 
-    <dependency id="org.apache.cordova.device" url="https://git-wip-us.apache.org/repos/asf/cordova-plugin-device.git" commit="master" subdir="." />
+    <dependency id="cordova-plugin-device" url="https://git-wip-us.apache.org/repos/asf/cordova-plugin-device.git" commit="master" subdir="." />
 
     <js-module src="www/PushNotification.js" name="PushNotification">
          <clobbers target="PushNotification" />


### PR DESCRIPTION
It looks like the Cordova project has changed the dependency id of `cordova-plugin-device` from `org.apache.cordova.device` to `cordova-plugin-device`. We need to update our dependency id to match it.

https://github.com/apache/cordova-plugin-device/blob/master/plugin.xml#L24