### PR TITLE
Update plugin path to urbanairship-cordova

### DIFF
--- a/scripts/copy_resources.js
+++ b/scripts/copy_resources.js
@@ -18,7 +18,7 @@ module.exports = function (context) {
     ///////////////////////////
         ios : [
             {
-                "plugins/com.urbanairship.cordova/src/ios/Airship/UI/Default/Common/Resources": "platforms/ios/" + projName
+                "plugins/urbanairship-cordova/src/ios/Airship/UI/Default/Common/Resources": "platforms/ios/" + projName
             }
         ]
     };


### PR DESCRIPTION
The path to the plugin has changed, and errors happen when you try to build or add the iOS platform.

![screenshot of screenfloat 24-04-15 11 03 51 am](https://cloud.githubusercontent.com/assets/811954/7309434/79af5a5c-ea72-11e4-958b-921056478b71.png)

I really appreciate that you work on and maintain the plugin, but its a bit frustrating to run into such a trivial bug.