### PR TITLE
Sending Activity context to PlayServicesUtils#handleAnyPlayServicesError

### DIFF
--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -152,7 +152,7 @@ public class UAirshipPlugin extends CordovaPlugin {
 
         // Handle any Google Play services errors
         if (PlayServicesUtils.isGooglePlayStoreAvailable()) {
-            PlayServicesUtils.handleAnyPlayServicesError(UAirship.getApplicationContext());
+            PlayServicesUtils.handleAnyPlayServicesError(cordova.getActivity());
         }
     }
 


### PR DESCRIPTION
When starting new activity using the application context, Android app will crash if the start intent does not have FLAG_ACTIVITY_NEW_TASK flag set.