### PR TITLE
Return device token from UARegistrationDelegate registrationSucceededForChannelID

### DIFF
--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -593,7 +593,13 @@ NSString *const EnableAnalyticsConfigKey = @"com.urbanairship.enable_analytics";
     UA_LINFO(@"Channel registration successful %@.", channelID);
 
     if (self.registrationCallbackID) {
-        NSDictionary *data = @{ @"channelID":channelID };
+        NSDictionary *data;
+        if (deviceToken == nil) {
+            data = @{ @"channelID":channelID };
+        }
+        else {
+            data = @{ @"channelID":channelID, @"deviceToken":deviceToken };
+        }
         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:data];
         [result setKeepCallbackAsBool:YES];
         [self.commandDelegate sendPluginResult:result callbackId:self.registrationCallbackID];

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -594,11 +594,10 @@ NSString *const EnableAnalyticsConfigKey = @"com.urbanairship.enable_analytics";
 
     if (self.registrationCallbackID) {
         NSDictionary *data;
-        if (deviceToken == nil) {
-            data = @{ @"channelID":channelID };
-        }
-        else {
+        if (deviceToken) {
             data = @{ @"channelID":channelID, @"deviceToken":deviceToken };
+        } else {
+            data = @{ @"channelID":channelID };
         }
         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:data];
         [result setKeepCallbackAsBool:YES];


### PR DESCRIPTION
Return the device token along with the channel ID from the urbanairship.registration event.  This is helpful to be able to send the device token to the back end server to be used with the UA API.