### PR TITLE
[MB-1787] do UI stuff on the main queue, gentler logging

### DIFF
--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -741,7 +741,9 @@ NSString *const EventRegistration = @"urbanairship.registration";
 
 - (void)displayMessageCenter:(CDVInvokedUrlCommand *)command {
     [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
-        [[UAirship defaultMessageCenter] display];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[UAirship defaultMessageCenter] display];
+        });
         completionHandler(CDVCommandStatus_OK, nil);
     }];
 }
@@ -829,7 +831,10 @@ NSString *const EventRegistration = @"urbanairship.registration";
 
         UINavigationController *navController =  [[UINavigationController alloc] initWithRootViewController:mvc];
 
-        [[UAUtils topController] presentViewController:navController animated:YES completion:nil];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[UAUtils topController] presentViewController:navController animated:YES completion:nil];
+        });
+
         completionHandler(CDVCommandStatus_OK, nil);
     }];
 }
@@ -845,7 +850,10 @@ NSString *const EventRegistration = @"urbanairship.registration";
             return;
         }
 
-        [UALandingPageOverlayController showMessage:message];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [UALandingPageOverlayController showMessage:message];
+        });
+
         completionHandler(CDVCommandStatus_OK, nil);
     }];
 }
@@ -862,7 +870,7 @@ NSString *const EventRegistration = @"urbanairship.registration";
 
 - (void)notifyListener:(NSString *)eventType data:(NSDictionary *)data {
     if (!self.listenerCallbackID) {
-        UA_LDEBUG(@"Listener callback unavailable. Unable to send event %@", eventType);
+        UA_LTRACE(@"Listener callback unavailable.  event %@", eventType);
         return;
     }
 

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -161,6 +161,7 @@ NSString *const EventRegistration = @"urbanairship.registration";
      NSArray --> Array
      NSDictionary --> Object
      NSNull --> no return value
+     nil -> no return value
      */
 
     // String
@@ -192,6 +193,11 @@ NSString *const EventRegistration = @"urbanairship.registration";
 
     // Null
     if ([value isKindOfClass:[NSNull class]]) {
+        return [CDVPluginResult resultWithStatus:status];
+    }
+
+    // Nil
+    if (!value) {
         return [CDVPluginResult resultWithStatus:status];
     }
 


### PR DESCRIPTION
We need to be careful about not making UI-related calls from the background, which is the default now for our plugin callbacks. Much of UIKit is not thread safe, leading to undefined behavior or this gnarly gem as reported by @linkmh:

```
bool _WebTryThreadLock(bool), 0x160805c00: Tried to obtain the web lock from a thread other than the main thread or the web thread. This may be a result of calling to UIKit from a secondary thread. Crashing now...
```

While we're at it, the log message about missing listeners is probably TMI for most cases so I bumped the log level up to trace in case it ever comes in handy.

I also added a bit to the plugin result logic that keeps it from logging an error when plugin calls don't return a value, which happens quite a lot now.