### PR TITLE
Adds the ability to set an associated identifier for use with Connect.

### DIFF
--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -758,7 +758,7 @@ public class UAirshipPlugin extends CordovaPlugin {
     /**
      * Sets associated custom identifiers for use with the Connect data stream.
      * <p/>
-     * Previous identifiers will be replaced by the new identifiers each time associateIdentifiers is called. It is a set operation.
+     * Previous identifiers will be replaced by the new identifiers each time setAssociateIdentifier is called. It is a set operation.
      * <p/>
      * Expected arguments: String
      *

--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -129,7 +129,7 @@ public class UAirshipPlugin extends CordovaPlugin {
             "getLaunchNotification", "getChannelID", "getQuietTime", "getTags", "getAlias", "setAlias", "setTags", "setSoundEnabled", "setVibrateEnabled",
             "setQuietTimeEnabled", "setQuietTime", "recordCurrentLocation", "clearNotifications", "registerListener", "setAnalyticsEnabled", "isAnalyticsEnabled",
             "setNamedUser", "getNamedUser", "runAction", "editNamedUserTagGroups", "editChannelTagGroups", "displayMessageCenter", "markInboxMessageRead",
-            "deleteInboxMessage", "getInboxMessages", "displayInboxMessage", "overlayInboxMessage", "refreshInbox", "getDeepLink");
+            "deleteInboxMessage", "getInboxMessages", "displayInboxMessage", "overlayInboxMessage", "refreshInbox", "getDeepLink", "setAssociatedIdentifier");
 
     /**
      * The launch push message. Set from the IntentReceiver.
@@ -753,6 +753,28 @@ public class UAirshipPlugin extends CordovaPlugin {
     void isAnalyticsEnabled(JSONArray data, CallbackContext callbackContext) {
         int value = UAirship.shared().getAnalytics().isEnabled() ? 1 : 0;
         callbackContext.success(value);
+    }
+
+    /**
+     * Sets associated custom identifiers for use with the Connect data stream.
+     * <p/>
+     * Previous identifiers will be replaced by the new identifiers each time associateIdentifiers is called. It is a set operation.
+     * <p/>
+     * Expected arguments: String
+     *
+     * @param data The call data.
+     * @param callbackContext The callback context.
+     */
+    void setAssociatedIdentifier(JSONArray data, CallbackContext callbackContext) throws JSONException {
+        String key = data.getString(0);
+        String identifier = data.getString(1);
+        
+        UAirship.shared().getAnalytics()
+           .editAssociatedIdentifiers()
+           .addIdentifier(key, identifier)
+           .apply();
+
+        callbackContext.success();
     }
 
     /**

--- a/src/ios/UAirshipPlugin.h
+++ b/src/ios/UAirshipPlugin.h
@@ -224,6 +224,17 @@
 - (void)setAnalyticsEnabled:(CDVInvokedUrlCommand *)command;
 
 /**
+ * Sets associated custom identifiers for use with the Connect data stream.
+ *
+ * Previous identifiers will be replaced by the new identifiers each time associateIdentifiers is called. It is a set operation.
+ *
+ * Expected arguments: An array of strings containing the identifier and key.
+ *
+ * @param command The cordova command.
+ */
+- (void)setAssociatedIdentifier:(CDVInvokedUrlCommand *)command;
+
+/**
  * Checks if analytics is enabled or not.
  *
  * @param command The cordova command.

--- a/src/ios/UAirshipPlugin.h
+++ b/src/ios/UAirshipPlugin.h
@@ -226,7 +226,7 @@
 /**
  * Sets associated custom identifiers for use with the Connect data stream.
  *
- * Previous identifiers will be replaced by the new identifiers each time associateIdentifiers is called. It is a set operation.
+ * Previous identifiers will be replaced by the new identifiers each time setAssociateIdentifier is called. It is a set operation.
  *
  * Expected arguments: An array of strings containing the identifier and key.
  *

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -39,6 +39,7 @@
 #import "UAMessageViewController.h"
 #import "UAUtils.h"
 #import "UADefaultMessageCenter.h"
+#import "UAAssociatedIdentifiers.h"
 
 typedef void (^UACordovaCompletionHandler)(CDVCommandStatus, id);
 typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandler completionHandler);
@@ -327,6 +328,19 @@ NSString *const EventRegistration = @"urbanairship.registration";
         NSNumber *value = [args objectAtIndex:0];
         BOOL enabled = [value boolValue];
         [UAirship shared].analytics.enabled = enabled;
+
+        completionHandler(CDVCommandStatus_OK, nil);
+    }];
+}
+
+- (void)setAssociatedIdentifier:(CDVInvokedUrlCommand *)command {
+    [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
+        NSString *key = [args objectAtIndex:0];
+        NSString *identifier = [args objectAtIndex:1];
+
+        UAAssociatedIdentifiers *identifiers = [[UAirship shared].analytics currentAssociatedDeviceIdentifiers];
+        [identifiers setIdentifier:identifier forKey:key];
+        [[UAirship shared].analytics associateDeviceIdentifiers:identifiers];
 
         completionHandler(CDVCommandStatus_OK, nil);
     }];

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -444,6 +444,20 @@ module.exports = {
     return new TagGroupEditor('editChannelTagGroups')
   },
 
+    /**
+   * Sets an associated identifer for the Connect data stream.
+   *
+   * @param {string} Custom key for identifier.
+   * @param {string} The identifer value.
+   * @param {function} [success] Success callback.
+   * @param {function(message)} [failure] Failure callback.
+   * @param {string} failure.message The error message.
+   */
+  setAssociatedIdentifier: function(key, identifer, success, failure) {
+    argscheck.checkArgs('ssFF', 'UAirship.setAssociatedIdentifier', arguments)
+    callNative(success, failure, "setAssociatedIdentifier", [key, identifer])
+  },
+
   // Location
 
   /**

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -444,18 +444,18 @@ module.exports = {
     return new TagGroupEditor('editChannelTagGroups')
   },
 
-    /**
-   * Sets an associated identifer for the Connect data stream.
+  /**
+   * Sets an associated identifier for the Connect data stream.
    *
    * @param {string} Custom key for identifier.
-   * @param {string} The identifer value.
+   * @param {string} The identifier value.
    * @param {function} [success] Success callback.
    * @param {function(message)} [failure] Failure callback.
    * @param {string} failure.message The error message.
    */
-  setAssociatedIdentifier: function(key, identifer, success, failure) {
+  setAssociatedIdentifier: function(key, identifier, success, failure) {
     argscheck.checkArgs('ssFF', 'UAirship.setAssociatedIdentifier', arguments)
-    callNative(success, failure, "setAssociatedIdentifier", [key, identifer])
+    callNative(success, failure, "setAssociatedIdentifier", [key, identifier])
   },
 
   // Location


### PR DESCRIPTION
Does not include the helper methods for setting advertising ids and properties. 