### PR TITLE
[MB-1962] Set notification large icon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Please contact support@urbanairship.com for any issues integrating or using this
 
         <!-- Override the Android notification icon -->
         <preference name="com.urbanairship.notification_icon" value="ic_notification" />
+
+        <!-- Override the Android notification large icon -->
+        <preference name="com.urbanairship.notification_large_icon" value="ic_notification_large" />
     
         <!-- Override the Android notification sound (sound file should be in res/raw)-->
         <preference name="com.urbanairship.notification_sound" value="push" />

--- a/jsdoc_readme.md
+++ b/jsdoc_readme.md
@@ -35,6 +35,9 @@
 
         <!-- Override the Android notification icon -->
         <preference name="com.urbanairship.notification_icon" value="ic_notification" />
+
+        <!-- Override the Android notification large icon -->
+        <preference name="com.urbanairship.notification_large_icon" value="ic_notification_large" />
     
         <!-- Override the Android notification sound (sound file should be in res/raw)-->
         <preference name="com.urbanairship.notification_sound" value="push" />

--- a/src/android/CordovaAutopilot.java
+++ b/src/android/CordovaAutopilot.java
@@ -119,7 +119,7 @@ public class CordovaAutopilot extends Autopilot {
         String notificationIconName = pluginConfig.getString(NOTIFICATION_ICON, null);
         if (!UAStringUtil.isEmpty(notificationIconName)) {
             int id  = context.getResources().getIdentifier(notificationIconName, "drawable", context.getPackageName());
-            if (id > 0) {
+            if (id != 0) {
                 factory.setSmallIconId(id);
             } else {
                 Logger.error("Unable to find notification icon with name: " + notificationIconName);
@@ -130,7 +130,7 @@ public class CordovaAutopilot extends Autopilot {
         String notificationLargeIconName = pluginConfig.getString(NOTIFICATION_LARGE_ICON, null);
         if (!UAStringUtil.isEmpty(notificationLargeIconName)) {
             int id  = context.getResources().getIdentifier(notificationLargeIconName, "drawable", context.getPackageName());
-            if (id > 0) {
+            if (id != 0) {
                 factory.setLargeIcon(id);
             } else {
                 Logger.error("Unable to find notification large icon with name: " + notificationLargeIconName);

--- a/src/android/CordovaAutopilot.java
+++ b/src/android/CordovaAutopilot.java
@@ -64,6 +64,7 @@ public class CordovaAutopilot extends Autopilot {
     static final String GCM_SENDER = "com.urbanairship.gcm_sender";
     static final String ENABLE_PUSH_ONLAUNCH = "com.urbanairship.enable_push_onlaunch";
     static final String NOTIFICATION_ICON = "com.urbanairship.notification_icon";
+    static final String NOTIFICATION_LARGE_ICON = "com.urbanairship.notification_large_icon";
     static final String NOTIFICATION_ACCENT_COLOR = "com.urbanairship.notification_accent_color";
     static final String NOTIFICATION_SOUND = "com.urbanairship.notification_sound";
     static final String AUTO_LAUNCH_MESSAGE_CENTER = "com.urbanairship.auto_launch_message_center";
@@ -122,6 +123,17 @@ public class CordovaAutopilot extends Autopilot {
                 factory.setSmallIconId(id);
             } else {
                 Logger.error("Unable to find notification icon with name: " + notificationIconName);
+            }
+        }
+
+        // Notification large icon
+        String notificationLargeIconName = pluginConfig.getString(NOTIFICATION_LARGE_ICON, null);
+        if (!UAStringUtil.isEmpty(notificationLargeIconName)) {
+            int id  = context.getResources().getIdentifier(notificationLargeIconName, "drawable", context.getPackageName());
+            if (id > 0) {
+                factory.setLargeIcon(id);
+            } else {
+                Logger.error("Unable to find notification large icon with name: " + notificationLargeIconName);
             }
         }
 


### PR DESCRIPTION
Allows configuring the plugin to use a custom notification large icon.

// config.xml
`<!-- Override the Android notification large icon -->`
`<preference name="com.urbanairship.notification_large_icon" value="ua_ic_close" />`

Example where the large icon is `X`:
![marshmallow_6_api_23_phonegap_large_icon_uaclosebutton_closeup](https://cloud.githubusercontent.com/assets/3409505/18601934/b655df72-7c1a-11e6-8d21-2fc6765a0dc0.png)
