### PR TITLE
[MB-1976] Added iOS 10 foreground presentation support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ Please contact support@urbanairship.com for any issues integrating or using this
         <!-- Enables/disables auto launching the message center when the corresponding push is opened. -->
         <preference name="com.urbanairship.auto_launch_message_center" value="true | false" />
 
+        <!-- iOS 10 alert foreground notification presentation option -->
+        <preference name="com.urbanairship.ios_foreground_notification_presentation_alert" value="true"/>
+
+        <!-- iOS 10 badge foreground notification presentation option -->
+        <preference name="com.urbanairship.ios_foreground_notification_presentation_badge" value="true"/>
+
+        <!-- iOS 10 sound foreground notification presentation option -->
+        <preference name="com.urbanairship.ios_foreground_notification_presentation_sound" value="true"/>
+
 
 4. Enable user notifications
 ```

--- a/jsdoc_readme.md
+++ b/jsdoc_readme.md
@@ -47,3 +47,12 @@
 
         <!-- Clear the iOS badge on launch -->
         <preference name="com.urbanairship.clear_badge_onlaunch" value="true | false" />
+
+        <!-- iOS 10 alert foreground notification presentation option -->
+        <preference name="com.urbanairship.ios_foreground_notification_presentation_alert" value="true"/>
+
+        <!-- iOS 10 badge foreground notification presentation option -->
+        <preference name="com.urbanairship.ios_foreground_notification_presentation_badge" value="true"/>
+
+        <!-- iOS 10 sound foreground notification presentation option -->
+        <preference name="com.urbanairship.ios_foreground_notification_presentation_sound" value="true"/>


### PR DESCRIPTION
Added iOS 10 foreground presentation support.

Specify the optional default foreground presentation options for iOS 10 via the config.xml:
```
<!-- iOS 10 alert foreground notification presentation option -->
<preference name="com.urbanairship.ios_foreground_notification_presentation_alert" value="true"/>

<!-- iOS 10 badge foreground notification presentation option -->
<preference name="com.urbanairship.ios_foreground_notification_presentation_badge" value="true"/>

<!-- iOS 10 sound foreground notification presentation option -->
<preference name="com.urbanairship.ios_foreground_notification_presentation_sound" value="true"/>
```

Testing:
* Tested foreground push notifications with various presentation options on iOS 10.0.2 iPod