### PR TITLE
[MB-1985] Fire event when notification opened.

### DIFF
--- a/Example/index.html
+++ b/Example/index.html
@@ -26,10 +26,10 @@
           }
         }
 
-         // Incoming message callback
-        var onLaunchedFromPush = function(event) {
+         // Notification opened callback
+        var notificationOpened = function(event) {
           if (event.message) {
-            console.log("Launched from push: " + event.message)
+            console.log("Notification opened: " + event.message)
           } else {
             console.log("No incoming message")
           }
@@ -45,7 +45,7 @@
           }
         }
 
-        //Deep link callback
+        // Deep link callback
         var handleDeepLink = function(event)  {
             console.log("Deep link: " + event.deepLink)
         }
@@ -53,6 +53,7 @@
         // Register for any urban airship events
         document.addEventListener("urbanairship.registration", onRegistration, false)
         document.addEventListener("urbanairship.push", onPushReceived, false)
+        document.addEventListener("urbanairship.notification_opened", notificationOpened, false)
         document.addEventListener("urbanairship.deep_link", handleDeepLink, false)
         
         // Handle resume
@@ -60,7 +61,6 @@
           console.log("Device resume!")
           
           UAirship.resetBadge()
-          UAirship.getLaunchNotification(true, onLaunchedFromPush)
 
           // Reregister for urbanairship events if they were removed in pause event
           document.addEventListener("urbanairship.registration", onRegistration, false)
@@ -80,7 +80,6 @@
         initiateUI()
         
         // Get the launch notification if its available.
-        UAirship.getLaunchNotification(true, onLaunchedFromPush)
       }
 
       // Initiates the UI and sets up any UI callbacks

--- a/plugin.xml
+++ b/plugin.xml
@@ -82,6 +82,7 @@
         <source-file src="src/android/events/DeepLinkEvent.java" target-dir="src/com/urbanairship/cordova/events" />
         <source-file src="src/android/events/InboxEvent.java" target-dir="src/com/urbanairship/cordova/events" />
         <source-file src="src/android/events/PushEvent.java" target-dir="src/com/urbanairship/cordova/events" />
+        <source-file src="src/android/events/NotificationOpenedEvent.java" target-dir="src/com/urbanairship/cordova/events" />
         <source-file src="src/android/events/Event.java" target-dir="src/com/urbanairship/cordova/events" />
 
         <source-file src="src/android/res/layout/ua_activity_landing_page.xml" target-dir="res/layout"/>

--- a/src/android/CordovaAirshipReceiver.java
+++ b/src/android/CordovaAirshipReceiver.java
@@ -79,7 +79,7 @@ public class CordovaAirshipReceiver extends AirshipReceiver {
     protected boolean onNotificationOpened(@NonNull Context context, @NonNull NotificationInfo notificationInfo) {
         Log.i(TAG, "Notification opened. Alert: " + notificationInfo.getMessage().getAlert() + ". NotificationId: " + notificationInfo.getNotificationId());
 
-        UAirshipPluginManager.shared().launchedFromPush(notificationInfo.getNotificationId(), notificationInfo.getMessage());
+        UAirshipPluginManager.shared().notificationOpened(notificationInfo.getNotificationId(), notificationInfo.getMessage());
 
         // Return false here to allow Urban Airship to auto launch the launcher activity
         return false;
@@ -89,7 +89,7 @@ public class CordovaAirshipReceiver extends AirshipReceiver {
     protected boolean onNotificationOpened(@NonNull Context context, @NonNull NotificationInfo notificationInfo, @NonNull ActionButtonInfo actionButtonInfo) {
         Log.i(TAG, "Notification action button opened. Button ID: " + actionButtonInfo.getButtonId() + ". NotificationId: " + notificationInfo.getNotificationId());
 
-        UAirshipPluginManager.shared().launchedFromPush(notificationInfo.getNotificationId(), notificationInfo.getMessage());
+        UAirshipPluginManager.shared().notificationOpened(notificationInfo.getNotificationId(), notificationInfo.getMessage());
 
         // Return false here to allow Urban Airship to auto launch the launcher
         // activity for foreground notification action buttons

--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -51,6 +51,7 @@ import com.urbanairship.actions.LandingPageActivity;
 import com.urbanairship.cordova.events.DeepLinkEvent;
 import com.urbanairship.cordova.events.Event;
 import com.urbanairship.cordova.events.PushEvent;
+import com.urbanairship.cordova.events.NotificationOpenedEvent;
 import com.urbanairship.google.PlayServicesUtils;
 import com.urbanairship.json.JsonValue;
 import com.urbanairship.messagecenter.MessageActivity;
@@ -409,7 +410,7 @@ public class UAirshipPlugin extends CordovaPlugin {
      */
     void getLaunchNotification(JSONArray data, CallbackContext callbackContext) {
         boolean clear = data.optBoolean(0, false);
-        PushEvent event = UAirshipPluginManager.shared().getLastLaunchNotificationEvent(clear);
+        NotificationOpenedEvent event = UAirshipPluginManager.shared().getLastLaunchNotificationEvent(clear);
 
         if (event != null) {
             callbackContext.success(event.getEventData());

--- a/src/android/UAirshipPluginManager.java
+++ b/src/android/UAirshipPluginManager.java
@@ -30,6 +30,7 @@ import com.urbanairship.cordova.events.DeepLinkEvent;
 import com.urbanairship.cordova.events.Event;
 import com.urbanairship.cordova.events.InboxEvent;
 import com.urbanairship.cordova.events.PushEvent;
+import com.urbanairship.cordova.events.NotificationOpenedEvent;
 import com.urbanairship.push.PushMessage;
 
 import java.util.ArrayList;
@@ -49,7 +50,7 @@ public class UAirshipPluginManager {
 
     private static final UAirshipPluginManager shared = new UAirshipPluginManager();
 
-    private PushEvent launchNotificationEvent;
+    private NotificationOpenedEvent notificationOpenedEvent;
     private DeepLinkEvent deepLinkEvent = null;
     private Listener listener = null;
 
@@ -101,16 +102,19 @@ public class UAirshipPluginManager {
     }
 
     /**
-     * Called when the app is launched from a push.
+     * Called when the notification is opened.
      *
      * @param notificationId The notification ID.
      * @param pushMessage The push message.
      */
-    void launchedFromPush(int notificationId, PushMessage pushMessage) {
+    void notificationOpened(int notificationId, PushMessage pushMessage) {
         synchronized (shared) {
-            PushEvent event = new PushEvent(notificationId, pushMessage);
-            this.launchNotificationEvent = event;
-            notifyListener(event);
+            NotificationOpenedEvent event = new NotificationOpenedEvent(notificationId, pushMessage);
+            this.notificationOpenedEvent = event;
+
+            if (!notifyListener(event)) {
+                pendingEvents.add(event);
+            }
         }
     }
 
@@ -142,16 +146,16 @@ public class UAirshipPluginManager {
     }
 
     /**
-     * Returns the last launch notification event.
+     * Returns the last notification opened event.
      *
      * @param clear {@code true} to clear the event, otherwise {@code false}.
-     * @return The deep link event, or null if the event is not available.
+     * @return The notification opened event, or null if the event is not available.
      */
-    public PushEvent getLastLaunchNotificationEvent(boolean clear) {
+    public NotificationOpenedEvent getLastLaunchNotificationEvent(boolean clear) {
         synchronized (shared) {
-            PushEvent event = this.launchNotificationEvent;
+            NotificationOpenedEvent event = this.notificationOpenedEvent;
             if (clear) {
-                this.launchNotificationEvent = null;
+                this.notificationOpenedEvent = null;
             }
 
             return event;

--- a/src/android/events/NotificationOpenedEvent.java
+++ b/src/android/events/NotificationOpenedEvent.java
@@ -1,0 +1,57 @@
+/*
+ Copyright 2009-2016 Urban Airship Inc. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.urbanairship.cordova.events;
+
+import com.urbanairship.Logger;
+import com.urbanairship.push.PushMessage;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Notification opened event.
+ */
+public class NotificationOpenedEvent extends PushEvent {
+
+    private static final String EVENT_NOTIFICATION_OPENED = "urbanairship.notification_opened";
+
+    private final PushMessage message;
+    private final Integer notificationId;
+
+    public NotificationOpenedEvent(Integer notificationId, PushMessage message) {
+        super(notificationId, message);
+        this.notificationId = notificationId;
+        this.message = message;
+    }
+
+    @Override
+    public String getEventName() {
+        return EVENT_NOTIFICATION_OPENED;
+    }
+}

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -162,6 +162,16 @@ module.exports = {
    */
 
   /**
+   * Event fired when notification opened.
+   *
+   * @event "urbanairship.notification_opened"
+   * @type {object}
+   * @param {string} message The push alert message.
+   * @param {object} extras Any push extras.
+   * @param {number} [notification_id] The Android notification ID.
+   */
+
+  /**
    * Enables or disables user notifications.
    *
    * @param {boolean} enabled true to enable notifications, false to disable.


### PR DESCRIPTION
Fire `urbanairship.notification_opened` event when notification opened.

Testing:

* Android log snippet
UrbanAirship.js:121 Firing document event: urbanairship.notification_opened
index.html:32 Notification opened: Alert - 4de9441c-a20e-4f5d-87ae-eff17138c2e8

* iOS log snippet
[Log] Firing document event: urbanairship.notification_opened (UrbanAirship.js, line 121)
[Log] Notification opened: Alert - 83664524-f671-4e21-ac3a-1586d913f57c (index.html, line 32)