### PR TITLE
Removed support email address from repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We accept pull requests! If you would like to submit a pull request, please fill
 
 ### Issues
 
-Please contact support@urbanairship.com for any issues integrating or using this plugin.
+Please visit http://support.urbanairship.com/ for any issues integrating or using this plugin.
 
 ### Requirements:
  - Android [GCM Setup](http://docs.urbanairship.com/reference/push-providers/gcm.html#android-gcm-setup)

--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
   ],
   "author": "Urban Airship",
   "license": "Apache 2.0",
-  "bugs": {
-    "email": "support@urbanairship.com"
-  },
   "homepage": "https://github.com/urbanairship/phonegap-ua-push#readme",
   "devDependencies": {
     "jsdoc": "3.4.0",


### PR DESCRIPTION
Hi all,

Per [SUPPORT-5868](https://tofurkey.urbanairship.com/browse/SUPPORT-5868):

The support@urbanairship.com email address is listed on the phonegap-ua-push repository on Github. We do not want this listed on a public repository as email support is reserved for paying customers. We direct any free customers to the forums, so I think it makes sense to list http://support.urbanairship.com/ in place of the support email address.

I only modified the README.md and the package.json file. I just removed the bugs field from the package.json. I can add it back in there if need be, and just replace 'email' with 'url' and make the url the support website. 