### PR TITLE
Require cordova-cli 6.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ We accept pull requests! If you would like to submit a pull request, please fill
 Please visit http://support.urbanairship.com/ for any issues integrating or using this plugin.
 
 ### Requirements:
+ - Cordova-CLI 6.4.0
  - Android [GCM Setup](http://docs.urbanairship.com/reference/push-providers/gcm.html#android-gcm-setup)
  - iOS [APNS Setup](http://docs.urbanairship.com/reference/push-providers/apns.html)
 


### PR DESCRIPTION
Update readme to require cordova-cli 6.4.0

Note: I think we can ignore the check failure, since this is a one line non-code change in readme file. I believe it is due to the new build machine and will fix it when I get into the office.