### PR TITLE
[MB-2057] Fixed deprecation warnings for iOS plugin and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ Please visit http://support.urbanairship.com/ for any issues integrating or usin
         <preference name="com.urbanairship.auto_launch_message_center" value="true | false" />
 
         <!-- iOS 10 alert foreground notification presentation option -->
-        <preference name="com.urbanairship.ios_foreground_notification_presentation_alert" value="true"/>
+        <preference name="com.urbanairship.ios_foreground_notification_presentation_alert" value="true | false"/>
 
         <!-- iOS 10 badge foreground notification presentation option -->
-        <preference name="com.urbanairship.ios_foreground_notification_presentation_badge" value="true"/>
+        <preference name="com.urbanairship.ios_foreground_notification_presentation_badge" value="true | false"/>
 
         <!-- iOS 10 sound foreground notification presentation option -->
-        <preference name="com.urbanairship.ios_foreground_notification_presentation_sound" value="true"/>
+        <preference name="com.urbanairship.ios_foreground_notification_presentation_sound" value="true | false"/>
 
 
 4. Enable user notifications

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -440,9 +440,9 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
 
             // these will be nil if the dateformatter can't make sense of either string
             if (startDate && endDate) {
-                NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
-                NSDateComponents *startComponents = [gregorian components:NSHourCalendarUnit|NSMinuteCalendarUnit fromDate:startDate];
-                NSDateComponents *endComponents = [gregorian components:NSHourCalendarUnit|NSMinuteCalendarUnit fromDate:endDate];
+                NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+                NSDateComponents *startComponents = [gregorian components:NSCalendarUnitHour|NSCalendarUnitMinute fromDate:startDate];
+                NSDateComponents *endComponents = [gregorian components:NSCalendarUnitHour|NSCalendarUnitMinute fromDate:endDate];
 
                 completionHandler(CDVCommandStatus_OK, @{ @"startHour": @(startComponents.hour),
                                                           @"startMinute": @(startComponents.minute),


### PR DESCRIPTION
Fixed deprecation warnings for iOS plugin and updated readme.

Testing:
* Verified quiet time enabled/disabled with specified times on iOS 10.1.1 iPod device