### PR TITLE
[MB-2081] Configure logging levels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Please visit http://support.urbanairship.com/ for any issues integrating or usin
         <!-- Warning: Features that depend on analytics being enabled may not work properly if analytics is disabled (reports, location segmentation, region triggers, push to local time). -->
         <preference name="com.urbanairship.enable_analytics" value="true | false" />
 
+        <!-- Urban Airship development log level defaults to debug -->
+        <preference name="com.urbanairship.development_log_level" value="none | error | warn | info | debug | verbose" />
+
+        <!-- Urban Airship production log level defaults to error -->
+        <preference name="com.urbanairship.production_log_level" value="none | error | warn | info | debug | verbose" />
+
         <!-- Override the Android notification icon -->
         <preference name="com.urbanairship.notification_icon" value="ic_notification" />
 

--- a/jsdoc_readme.md
+++ b/jsdoc_readme.md
@@ -33,6 +33,12 @@
         <!-- Warning: Features that depend on analytics being enabled may not work properly if analytics is disabled (reports, location segmentation, region triggers, push to local time). -->
         <preference name="com.urbanairship.enable_analytics" value="true | false" />
 
+        <!-- Urban Airship development log level defaults to debug -->
+        <preference name="com.urbanairship.development_log_level" value="none | error | warn | info | debug | verbose" />
+
+        <!-- Urban Airship production log level defaults to error -->
+        <preference name="com.urbanairship.production_log_level" value="none | error | warn | info | debug | verbose" />
+
         <!-- Override the Android notification icon -->
         <preference name="com.urbanairship.notification_icon" value="ic_notification" />
 

--- a/src/android/CordovaAutopilot.java
+++ b/src/android/CordovaAutopilot.java
@@ -63,6 +63,8 @@ public class CordovaAutopilot extends Autopilot {
     static final String PRODUCTION_SECRET = "com.urbanairship.production_app_secret";
     static final String DEVELOPMENT_KEY = "com.urbanairship.development_app_key";
     static final String DEVELOPMENT_SECRET = "com.urbanairship.development_app_secret";
+    static final String PRODUCTION_LOG_LEVEL = "com.urbanairship.production_log_level";
+    static final String DEVELOPMENT_LOG_LEVEL = "com.urbanairship.development_log_level";
     static final String IN_PRODUCTION = "com.urbanairship.in_production";
     static final String GCM_SENDER = "com.urbanairship.gcm_sender";
     static final String ENABLE_PUSH_ONLAUNCH = "com.urbanairship.enable_push_onlaunch";
@@ -90,6 +92,8 @@ public class CordovaAutopilot extends Autopilot {
                 .setInProduction(pluginConfig.getBoolean(IN_PRODUCTION, false))
                 .setGcmSender(pluginConfig.getString(GCM_SENDER, ""))
                 .setAnalyticsEnabled(pluginConfig.getBoolean(ENABLE_ANALYTICS, true))
+                .setDevelopmentLogLevel(androidLogLevel(pluginConfig.getString(DEVELOPMENT_LOG_LEVEL, "debug")))
+                .setProductionLogLevel(androidLogLevel(pluginConfig.getString(PRODUCTION_LOG_LEVEL, "error")))
                 .build();
 
         return options;
@@ -221,6 +225,31 @@ public class CordovaAutopilot extends Autopilot {
         }
 
         return pluginConfig;
+    }
+
+    /**
+     * Convert the log level string to an int.
+     *
+     * @param logLevel The log level string.
+     * @return The log level.
+     */
+    public int androidLogLevel(String logLevel) {
+        String logString = logLevel.toLowerCase();
+        if (logString.equals("verbose")) {
+            return 2;
+        } else if (logString.equals("debug")) {
+            return 3;
+        } else if (logString.equals("info")) {
+            return 4;
+        } else if (logString.equals("warn")) {
+            return 5;
+        } else if (logString.equals("error")) {
+            return 6;
+        } else if (logString.equals("none")) {
+            return 7;
+        } else {
+            return 7; // default to none
+        }
     }
 
     /**

--- a/src/android/CordovaAutopilot.java
+++ b/src/android/CordovaAutopilot.java
@@ -31,6 +31,7 @@ import android.content.res.XmlResourceParser;
 import android.graphics.Color;
 import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 import com.urbanairship.AirshipConfigOptions;
 import com.urbanairship.Autopilot;
@@ -92,8 +93,8 @@ public class CordovaAutopilot extends Autopilot {
                 .setInProduction(pluginConfig.getBoolean(IN_PRODUCTION, false))
                 .setGcmSender(pluginConfig.getString(GCM_SENDER, ""))
                 .setAnalyticsEnabled(pluginConfig.getBoolean(ENABLE_ANALYTICS, true))
-                .setDevelopmentLogLevel(androidLogLevel(pluginConfig.getString(DEVELOPMENT_LOG_LEVEL, "debug")))
-                .setProductionLogLevel(androidLogLevel(pluginConfig.getString(PRODUCTION_LOG_LEVEL, "error")))
+                .setDevelopmentLogLevel(parseLogLevel(pluginConfig.getString(DEVELOPMENT_LOG_LEVEL, ""), Log.DEBUG))
+                .setProductionLogLevel(parseLogLevel(pluginConfig.getString(PRODUCTION_LOG_LEVEL, ""), Log.ERROR))
                 .build();
 
         return options;
@@ -230,25 +231,29 @@ public class CordovaAutopilot extends Autopilot {
     /**
      * Convert the log level string to an int.
      *
-     * @param logLevel The log level string.
+     * @param logLevel The log level as a string.
+     * @param defaultLogLevel Default log level.
      * @return The log level.
      */
-    public int androidLogLevel(String logLevel) {
-        String logString = logLevel.toLowerCase();
+    int parseLogLevel(String logLevel, int defaultLogLevel) {
+        if (logLevel == null || logLevel.length() == 0) {
+            return defaultLogLevel;
+        }
+        String logString = logLevel.trim().toLowerCase();
         if (logString.equals("verbose")) {
-            return 2;
+            return Log.VERBOSE;
         } else if (logString.equals("debug")) {
-            return 3;
+            return Log.DEBUG;
         } else if (logString.equals("info")) {
-            return 4;
+            return Log.INFO;
         } else if (logString.equals("warn")) {
-            return 5;
+            return Log.WARN;
         } else if (logString.equals("error")) {
-            return 6;
+            return Log.ERROR;
         } else if (logString.equals("none")) {
-            return 7;
+            return Log.ASSERT;
         } else {
-            return 7; // default to none
+            return defaultLogLevel;
         }
     }
 

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -84,12 +84,12 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     config.developmentAppSecret = settings[DevelopmentAppSecretConfigKey];
     config.inProduction = [settings[ProductionConfigKey] boolValue];
     if (settings[DevelopmentLogLevelKey] != nil) {
-        config.developmentLogLevel = [self iOSLogLevel:settings[DevelopmentLogLevelKey]];
+        config.developmentLogLevel = [self parseLogLevel:settings[DevelopmentLogLevelKey] defaultLogLevel:UALogLevelDebug];
     } else {
         config.developmentLogLevel = UALogLevelDebug;
     }
     if (settings[ProductionLogLevelKey] != nil) {
-        config.productionLogLevel = [self iOSLogLevel:settings[ProductionLogLevelKey]];
+        config.productionLogLevel = [self parseLogLevel:settings[ProductionLogLevelKey] defaultLogLevel:UALogLevelError];
     } else {
         config.productionLogLevel = UALogLevelError;
     }
@@ -918,22 +918,26 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     return result;
 }
 
--(int)iOSLogLevel:(NSString *)logLevel {
-    NSString *logString = [logLevel lowercaseString];
-    if ([logString isEqualToString:@"verbose"]) {
-        return 5;
-    } else if ([logString isEqualToString:@"debug"]) {
-        return 4;
-    } else if ([logString isEqualToString:@"info"]) {
-        return 3;
-    } else if ([logString isEqualToString:@"warning"]) {
-        return 2;
-    } else if ([logString isEqualToString:@"error"]) {
-        return 1;
-    } else if ([logString isEqualToString:@"none"]) {
-        return 0;
+-(int)parseLogLevel:(NSString *)logLevel defaultLogLevel:(NSInteger)defaultValue {
+    if (logLevel == nil || logLevel.length == 0) {
+        return defaultValue;
     }
-    return 0; // default to none
+    logLevel = [logLevel stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    logLevel = [logLevel lowercaseString];
+    if ([logLevel isEqualToString:@"verbose"]) {
+        return UALogLevelTrace;
+    } else if ([logLevel isEqualToString:@"debug"]) {
+        return UALogLevelDebug;
+    } else if ([logLevel isEqualToString:@"info"]) {
+        return UALogLevelInfo;
+    } else if ([logLevel isEqualToString:@"warning"]) {
+        return UALogLevelWarn;
+    } else if ([logLevel isEqualToString:@"error"]) {
+        return UALogLevelError;
+    } else if ([logLevel isEqualToString:@"none"]) {
+        return UALogLevelNone;
+    }
+    return defaultValue;
 }
 
 @end

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -44,6 +44,8 @@ NSString *const ProductionAppKeyConfigKey = @"com.urbanairship.production_app_ke
 NSString *const ProductionAppSecretConfigKey = @"com.urbanairship.production_app_secret";
 NSString *const DevelopmentAppKeyConfigKey = @"com.urbanairship.development_app_key";
 NSString *const DevelopmentAppSecretConfigKey = @"com.urbanairship.development_app_secret";
+NSString *const ProductionLogLevelKey = @"com.urbanairship.production_log_level";
+NSString *const DevelopmentLogLevelKey = @"com.urbanairship.development_log_level";
 NSString *const ProductionConfigKey = @"com.urbanairship.in_production";
 NSString *const EnablePushOnLaunchConfigKey = @"com.urbanairship.enable_push_onlaunch";
 NSString *const ClearBadgeOnLaunchConfigKey = @"com.urbanairship.clear_badge_onlaunch";
@@ -81,8 +83,16 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     config.developmentAppKey = settings[DevelopmentAppKeyConfigKey];
     config.developmentAppSecret = settings[DevelopmentAppSecretConfigKey];
     config.inProduction = [settings[ProductionConfigKey] boolValue];
-    config.developmentLogLevel = UALogLevelTrace;
-    config.productionLogLevel = UALogLevelTrace;
+    if (settings[DevelopmentLogLevelKey] != nil) {
+        config.developmentLogLevel = [self iOSLogLevel:settings[DevelopmentLogLevelKey]];
+    } else {
+        config.developmentLogLevel = UALogLevelDebug;
+    }
+    if (settings[ProductionLogLevelKey] != nil) {
+        config.productionLogLevel = [self iOSLogLevel:settings[ProductionLogLevelKey]];
+    } else {
+        config.productionLogLevel = UALogLevelError;
+    }
 
     // Analytics. Enabled by Default
     if (settings[EnableAnalyticsConfigKey] != nil) {
@@ -908,5 +918,22 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     return result;
 }
 
+-(int)iOSLogLevel:(NSString *)logLevel {
+    NSString *logString = [logLevel lowercaseString];
+    if ([logString isEqualToString:@"verbose"]) {
+        return 5;
+    } else if ([logString isEqualToString:@"debug"]) {
+        return 4;
+    } else if ([logString isEqualToString:@"info"]) {
+        return 3;
+    } else if ([logString isEqualToString:@"warning"]) {
+        return 2;
+    } else if ([logString isEqualToString:@"error"]) {
+        return 1;
+    } else if ([logString isEqualToString:@"none"]) {
+        return 0;
+    }
+    return 0; // default to none
+}
 
 @end


### PR DESCRIPTION
Configure logging levels for Android and iOS:
* Set default production log level to `error`
* Set default development log level to `debug`
* Optionally set log levels via config.xml:
```
<!-- Urban Airship development log level defaults to debug -->
<preference name="com.urbanairship.development_log_level" value="none | error | warn | info | debug | verbose" />
<!-- Urban Airship production log level defaults to error -->
<preference name="com.urbanairship.production_log_level" value="none | error | warn | info | debug | verbose" />
```

Testing:
* Tested on iPod and nexus5x and verified logs
