### PR TITLE
Release 6.5.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,10 @@
 ============================
+Version 6.5.0 - Jan 30, 2017
+============================
+ - Update Android Urban Airship SDK to use the latest version of play services.
+ - Updated Android Urban Airship SDK to 8.2.5
+
+============================
 Version 6.4.0 - Jan 6, 2017
 ============================
  - Added support for configuring logging levels.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-cordova",
-  "version": "6.4.0",
+  "version": "6.5.0",
   "description": "Urban Airship Cordova plugin",
   "cordova": {
     "id": "urbanairship-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="urbanairship-cordova"
-    version="6.4.0">
+    version="6.5.0">
 
     <name>Urban Airship</name>
     <description>Urban Airship Cordova plugin</description>

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -11,12 +11,12 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:24.2.0'
-    compile 'com.android.support:cardview-v7:24.2.0'
-    compile 'com.android.support:support-annotations:24.2.0'
-    compile 'com.google.android.gms:play-services-gcm:[9.4.0,10['
-    compile 'com.google.android.gms:play-services-location:[9.4.0,10['
-    compile 'com.urbanairship.android:urbanairship-sdk:8.0.1'
+    compile 'com.android.support:support-v4:25.1.0'
+    compile 'com.android.support:cardview-v7:25.1.0'
+    compile 'com.android.support:support-annotations:25.1.0'
+    compile 'com.google.android.gms:play-services-gcm:[9.4.0,)'
+    compile 'com.google.android.gms:play-services-location:[9.4.0,)'
+    compile 'com.urbanairship.android:urbanairship-sdk:8.2.5'
 }
 
 def getPackageName() {


### PR DESCRIPTION
Release 6.5.0
* Update Android Urban Airship SDK to use latest version of play services.
* Updated Android Urban Airship SDK to 8.2.5

Testing:
* Ran sample on Android Nexus 5x device and received push. Verified console log UA Lib version = 8.2.5