### PR TITLE
MB-2078: Dismiss Message Ctr, Inbox Message and Overlay Inbox Message

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -72,12 +72,58 @@
                 </intent-filter>
             </activity>
 
+        <activity android:name="com.urbanairship.cordova.CustomMessageActivity"
+                  android:theme="@android:style/Theme.DeviceDefault.Light">
+            <intent-filter>
+                <action android:name="com.urbanairship.VIEW_RICH_PUSH_MESSAGE" />
+                <data android:scheme="message"/>
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+            <activity
+                android:name="com.urbanairship.cordova.CustomMessageCenterActivity"
+                android:launchMode="singleTask"
+                android:theme="@android:style/Theme.DeviceDefault.Light">
+
+                <intent-filter>
+                    <action android:name="com.urbanairship.VIEW_RICH_PUSH_INBOX" />
+                    <category android:name="android.intent.category.DEFAULT" />
+                </intent-filter>
+
+                <intent-filter>
+                    <action android:name="com.urbanairship.VIEW_RICH_PUSH_INBOX"/>
+                    <data android:scheme="message"/>
+                    <category android:name="android.intent.category.DEFAULT"/>
+                </intent-filter>
+            </activity>
+
+            <activity android:name="com.urbanairship.cordova.CustomLandingPageActivity"
+                  xmlns:tools="http://schemas.android.com/tools"
+                  android:exported="false" android:theme="@style/LandingPageStyle"
+                  tools:node="replace">
+                <meta-data android:name="com.urbanairship.action.LANDING_PAGE_VIEW"
+                           android:resource="@layout/ua_activity_landing_page"/>
+                <meta-data android:name="com.urbanairship.push.iam.EXCLUDE_FROM_AUTO_SHOW"
+                           android:value="true"/>
+                <intent-filter>
+                    <action android:name="com.urbanairship.actions.SHOW_LANDING_PAGE_INTENT_ACTION"/>
+                    <data android:scheme="http"/>
+                    <data android:scheme="https"/>
+                    <data android:scheme="message"/>
+                    <category android:name="android.intent.category.DEFAULT"/>
+                </intent-filter>
+            </activity>
+
         </config-file>
 
         <source-file src="src/android/UAirshipPlugin.java" target-dir="src/com/urbanairship/cordova" />
         <source-file src="src/android/CordovaAirshipReceiver.java" target-dir="src/com/urbanairship/cordova" />
         <source-file src="src/android/CordovaAutopilot.java" target-dir="src/com/urbanairship/cordova" />
         <source-file src="src/android/CordovaLandingPageView.java" target-dir="src/com/urbanairship/cordova" />
+        <source-file src="src/android/CustomMessageActivity.java" target-dir="src/com/urbanairship/cordova" />
+        <source-file src="src/android/CustomMessageCenterActivity.java" target-dir="src/com/urbanairship/cordova" />
+        <source-file src="src/android/CustomLandingPageActivity.java" target-dir="src/com/urbanairship/cordova" />
         <source-file src="src/android/UAirshipPluginManager.java" target-dir="src/com/urbanairship/cordova" />
         <source-file src="src/android/events/ChannelEvent.java" target-dir="src/com/urbanairship/cordova/events" />
         <source-file src="src/android/events/DeepLinkEvent.java" target-dir="src/com/urbanairship/cordova/events" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -90,12 +90,6 @@
                     <action android:name="com.urbanairship.VIEW_RICH_PUSH_INBOX" />
                     <category android:name="android.intent.category.DEFAULT" />
                 </intent-filter>
-
-                <intent-filter>
-                    <action android:name="com.urbanairship.VIEW_RICH_PUSH_INBOX"/>
-                    <data android:scheme="message"/>
-                    <category android:name="android.intent.category.DEFAULT"/>
-                </intent-filter>
             </activity>
 
             <activity android:name="com.urbanairship.cordova.CustomLandingPageActivity"

--- a/src/android/CustomLandingPageActivity.java
+++ b/src/android/CustomLandingPageActivity.java
@@ -1,0 +1,55 @@
+/*
+ Copyright 2009-2017 Urban Airship Inc. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.urbanairship.cordova;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.urbanairship.actions.LandingPageActivity;
+
+public class CustomLandingPageActivity extends LandingPageActivity {
+
+    @Override
+    public void onPostCreate(Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
+
+        if (getIntent() != null && "CANCEL".equals(getIntent().getAction())) {
+            finish();
+        }
+
+    }
+
+    @Override
+    public void onNewIntent(Intent intent) {
+
+        if (intent != null && "CANCEL".equals(intent.getAction())) {
+            finish();
+            return;
+        }
+
+        super.onNewIntent(intent);
+    }
+}

--- a/src/android/CustomMessageActivity.java
+++ b/src/android/CustomMessageActivity.java
@@ -1,0 +1,81 @@
+/*
+ Copyright 2009-2017 Urban Airship Inc. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.urbanairship.cordova;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+
+import com.urbanairship.Logger;
+import com.urbanairship.messagecenter.MessageActivity;
+import com.urbanairship.richpush.RichPushInbox;
+
+public class CustomMessageActivity extends MessageActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (getIntent() != null && "CLOSE".equals(getIntent().getAction())) {
+            finish();
+        }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+
+        if (intent != null && "CLOSE".equals(intent.getAction())) {
+            finish();
+            return;
+        }
+
+        String messageId = null;
+
+        // Handle the "com.urbanairship.VIEW_RICH_PUSH_MESSAGE" intent action with the message
+        // ID encoded in the intent's data in the form of "message:<MESSAGE_ID>
+        if (getIntent() != null && getIntent().getData() != null
+                && RichPushInbox.VIEW_MESSAGE_INTENT_ACTION.equals(getIntent().getAction())) {
+            messageId = intent.getData().getSchemeSpecificPart();
+
+            Logger.debug("Relaunching activity");
+
+            finish();
+
+            Intent restartIntent = new Intent()
+                    .setClass(this, this.getClass())
+                    .setAction(RichPushInbox.VIEW_MESSAGE_INTENT_ACTION)
+                    .setData(Uri.fromParts(RichPushInbox.MESSAGE_DATA_SCHEME, messageId, null))
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
+            if (intent.getExtras() != null) {
+                restartIntent.putExtras(intent.getExtras());
+            }
+
+            this.startActivity(restartIntent);
+        }
+    }
+}

--- a/src/android/CustomMessageCenterActivity.java
+++ b/src/android/CustomMessageCenterActivity.java
@@ -1,0 +1,53 @@
+/*
+ Copyright 2009-2017 Urban Airship Inc. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.urbanairship.cordova;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.urbanairship.messagecenter.MessageCenterActivity;
+
+public class CustomMessageCenterActivity extends MessageCenterActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (getIntent() != null && "CLOSE".equals(getIntent().getAction())) {
+            finish();
+        }
+
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+
+        if (intent != null && "CLOSE".equals(intent.getAction())) {
+            finish();
+        }
+    }
+}

--- a/src/android/CustomMessageCenterActivity.java
+++ b/src/android/CustomMessageCenterActivity.java
@@ -29,6 +29,8 @@ import android.content.Intent;
 import android.os.Bundle;
 
 import com.urbanairship.messagecenter.MessageCenterActivity;
+import com.urbanairship.messagecenter.MessageCenterFragment;
+import com.urbanairship.richpush.RichPushInbox;
 
 public class CustomMessageCenterActivity extends MessageCenterActivity {
 
@@ -38,8 +40,15 @@ public class CustomMessageCenterActivity extends MessageCenterActivity {
 
         if (getIntent() != null && "CLOSE".equals(getIntent().getAction())) {
             finish();
+            return;
         }
 
+        if (getIntent() != null && getIntent().getData() != null && RichPushInbox.VIEW_INBOX_INTENT_ACTION.equals(getIntent().getAction())) {
+            String messageId = getIntent().getData().getSchemeSpecificPart();
+            getSupportFragmentManager().executePendingTransactions();
+            MessageCenterFragment fragment = (MessageCenterFragment) getSupportFragmentManager().findFragmentByTag("MESSAGE_CENTER_FRAGMENT");
+            fragment.setMessageID(messageId);
+        }
     }
 
     @Override
@@ -48,6 +57,17 @@ public class CustomMessageCenterActivity extends MessageCenterActivity {
 
         if (intent != null && "CLOSE".equals(intent.getAction())) {
             finish();
+            return;
+        }
+
+        if (intent != null && intent.getData() != null && intent.getAction() != null) {
+            String s = intent.getAction();
+            if (s.equals(RichPushInbox.VIEW_MESSAGE_INTENT_ACTION) || s.equals(RichPushInbox.VIEW_INBOX_INTENT_ACTION)) {
+                String messageId = getIntent().getData().getSchemeSpecificPart();
+                MessageCenterFragment fragment = (MessageCenterFragment) getSupportFragmentManager().findFragmentByTag("MESSAGE_CENTER_FRAGMENT");
+                fragment.setMessageID(messageId);
+
+            }
         }
     }
 }

--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -104,7 +104,7 @@ public class UAirshipPlugin extends CordovaPlugin {
             "setQuietTimeEnabled", "setQuietTime", "recordCurrentLocation", "clearNotifications", "registerListener", "setAnalyticsEnabled", "isAnalyticsEnabled",
             "setNamedUser", "getNamedUser", "runAction", "editNamedUserTagGroups", "editChannelTagGroups", "displayMessageCenter", "markInboxMessageRead",
             "deleteInboxMessage", "getInboxMessages", "displayInboxMessage", "overlayInboxMessage", "refreshInbox", "getDeepLink", "setAssociatedIdentifier",
-            "isAppNotificationsEnabled", "setDisplayASAPEnabled");
+            "isAppNotificationsEnabled", "setDisplayASAPEnabled", "dismissMessageCenter", "dismissInboxMessage", "dismissOverlayInboxMessage");
 
     private ExecutorService executorService = Executors.newFixedThreadPool(1);
 
@@ -898,10 +898,37 @@ public class UAirshipPlugin extends CordovaPlugin {
 
         Logger.debug("Displaying Message Center");
         if (messageId != null) {
-            UAirship.shared().getInbox().startMessageActivity(messageId);
+            Intent intent = new Intent(cordova.getActivity(), CustomMessageCenterActivity.class)
+                        .setAction(RichPushInbox.VIEW_MESSAGE_INTENT_ACTION)
+                        .setPackage(cordova.getActivity().getPackageName())
+                        .setData(Uri.fromParts(RichPushInbox.MESSAGE_DATA_SCHEME, messageId, null))
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
+                cordova.getActivity().startActivity(intent);
         } else {
-            UAirship.shared().getInbox().startInboxActivity();
+            Intent intent = new Intent(cordova.getActivity(), CustomMessageCenterActivity.class)
+                        .setPackage(cordova.getActivity().getPackageName())
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
+                cordova.getActivity().startActivity(intent);
         }
+        callbackContext.success();
+    }
+
+    /**
+     * Dismiss the message center.
+     *
+     * @param data The call data. The message ID is expected to be the first entry.
+     * @param callbackContext The callback context.
+     * @throws JSONException
+     */
+    void dismissMessageCenter(JSONArray data, CallbackContext callbackContext) throws JSONException {
+        Logger.debug("Dismissing Message Center");
+        Intent intent = new Intent(cordova.getActivity(), CustomMessageCenterActivity.class)
+                    .setAction("CLOSE");
+
+        cordova.getActivity().startActivity(intent);
+
         callbackContext.success();
     }
 
@@ -997,7 +1024,7 @@ public class UAirshipPlugin extends CordovaPlugin {
         cordova.getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                Intent intent = new Intent(cordova.getActivity(), MessageActivity.class)
+                Intent intent = new Intent(cordova.getActivity(), CustomMessageActivity.class)
                         .setAction(RichPushInbox.VIEW_MESSAGE_INTENT_ACTION)
                         .setPackage(cordova.getActivity().getPackageName())
                         .setData(Uri.fromParts(RichPushInbox.MESSAGE_DATA_SCHEME, messageId, null))
@@ -1011,7 +1038,25 @@ public class UAirshipPlugin extends CordovaPlugin {
     }
 
     /**
-     * Displays an inbox message using the LandingPageActivity.
+     * Dismiss the inbox message.
+     *
+     * @param data The call data. The message ID is expected to be the first entry.
+     * @param callbackContext The callback context.
+     * @throws JSONException
+     */
+    void dismissInboxMessage(JSONArray data, CallbackContext callbackContext) throws JSONException {
+        Logger.debug("Dismissing Inbox Message");
+        Intent intent = new Intent(cordova.getActivity(), CustomMessageActivity.class)
+                .setAction("CLOSE")
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
+        cordova.getActivity().startActivity(intent);
+
+        callbackContext.success();
+    }
+
+    /**
+     * Displays an inbox message using the CustomLandingPageActivity.
      *
      * @param data The call data. The message ID is expected to be the first entry.
      * @param callbackContext The callback context.
@@ -1029,7 +1074,7 @@ public class UAirshipPlugin extends CordovaPlugin {
         cordova.getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                Intent intent = new Intent(cordova.getActivity(), LandingPageActivity.class)
+                Intent intent = new Intent(cordova.getActivity(), CustomLandingPageActivity.class)
                         .setAction(RichPushInbox.VIEW_MESSAGE_INTENT_ACTION)
                         .setPackage(cordova.getActivity().getPackageName())
                         .setData(Uri.fromParts(RichPushInbox.MESSAGE_DATA_SCHEME, messageId, null))
@@ -1038,6 +1083,24 @@ public class UAirshipPlugin extends CordovaPlugin {
                 cordova.getActivity().startActivity(intent);
             }
         });
+
+        callbackContext.success();
+    }
+
+    /**
+     * Dismiss the overlay inbox message.
+     *
+     * @param data The call data. The message ID is expected to be the first entry.
+     * @param callbackContext The callback context.
+     * @throws JSONException
+     */
+    void dismissOverlayInboxMessage(JSONArray data, CallbackContext callbackContext) throws JSONException {
+        Logger.debug("Dismissing Overlay Inbox Message");
+        Intent intent = new Intent(cordova.getActivity(), CustomLandingPageActivity.class)
+                .setAction("CANCEL")
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
+        cordova.getActivity().startActivity(intent);
 
         callbackContext.success();
     }

--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -904,13 +904,13 @@ public class UAirshipPlugin extends CordovaPlugin {
                         .setData(Uri.fromParts(RichPushInbox.MESSAGE_DATA_SCHEME, messageId, null))
                         .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
-                cordova.getActivity().startActivity(intent);
+            cordova.getActivity().startActivity(intent);
         } else {
             Intent intent = new Intent(cordova.getActivity(), CustomMessageCenterActivity.class)
                         .setPackage(cordova.getActivity().getPackageName())
                         .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
-                cordova.getActivity().startActivity(intent);
+            cordova.getActivity().startActivity(intent);
         }
         callbackContext.success();
     }

--- a/src/ios/UAirshipPlugin.h
+++ b/src/ios/UAirshipPlugin.h
@@ -324,9 +324,16 @@
 /**
  * Display the given message without animation.
  *
- * @pararm message The message.
+ * @param command The cordova command.
  */
 - (void)displayMessageCenter:(CDVInvokedUrlCommand *)command;
+
+/**
+ * Dismiss the message center.
+ *
+ * @param command The cordova command.
+ */
+- (void)dismissMessageCenter:(CDVInvokedUrlCommand *)command;
 
 /**
  * Gets the inbox listing.
@@ -363,6 +370,13 @@
 - (void)displayInboxMessage:(CDVInvokedUrlCommand *)command;
 
 /**
+ * Dismiss an inbox message.
+ *
+ * @param command The cordova command.
+ */
+- (void)dismissInboxMessage:(CDVInvokedUrlCommand *)command;
+
+/**
  * Displays an inbox message in the overlay.
  *
  * Expected arguments: String - message ID.
@@ -370,6 +384,13 @@
  * @param command The cordova command.
  */
 - (void)overlayInboxMessage:(CDVInvokedUrlCommand *)command;
+
+/**
+ * Dismiss an inbox message in the overlay.
+ *
+ * @param command The cordova command.
+ */
+- (void)dismissOverlayInboxMessage:(CDVInvokedUrlCommand *)command;
 
 /**
  * Refreshes the inbox.

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -953,7 +953,7 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     return result;
 }
 
--(long)parseLogLevel:(NSString *)logLevel defaultLogLevel:(NSInteger)defaultValue {
+-(NSInteger)parseLogLevel:(NSString *)logLevel defaultLogLevel:(NSInteger)defaultValue {
     if (logLevel == nil || logLevel.length == 0) {
         return defaultValue;
     }

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -576,6 +576,42 @@ module.exports = {
   },
 
   /**
+   * Dismiss the message center.
+   *
+   * @param {function} [success] Success callback.
+   * @param {function(message)} [failure] Failure callback.
+   * @param {string} failure.message The error message.
+   */
+  dismissMessageCenter: function(success, failure) {
+    argscheck.checkArgs('FF', 'UAirship.dismissMessageCenter', arguments)
+    callNative(success, failure, "dismissMessageCenter")
+  },
+
+  /**
+   * Dismiss the inbox message.
+   *
+   * @param {function} [success] Success callback.
+   * @param {function(message)} [failure] Failure callback.
+   * @param {string} failure.message The error message.
+   */
+  dismissInboxMessage: function(success, failure) {
+    argscheck.checkArgs('FF', 'UAirship.dismissInboxMessage', arguments)
+    callNative(success, failure, "dismissInboxMessage")
+  },
+
+  /**
+   * Dismiss the inbox message in the overlay.
+   *
+   * @param {function} [success] Success callback.
+   * @param {function(message)} [failure] Failure callback.
+   * @param {string} failure.message The error message.
+   */
+  dismissOverlayInboxMessage: function(success, failure) {
+    argscheck.checkArgs('FF', 'UAirship.dismissOverlayInboxMessage', arguments)
+    callNative(success, failure, "dismissOverlayInboxMessage")
+  },
+
+  /**
    * Gets the array of inbox messages. Each message will have the following properties:
    * "id": string - The messages ID. Needed to display, mark as read, or delete the message.
    * "title": string - The message title.


### PR DESCRIPTION
New methods:
* `dismissMessageCenter` closes the message center from `displayMessageCenter`
* `dismissInboxMessage` closes the inbox message from `displayInboxMessage`
* `dismissOverlayInboxMessage` closes the overlay inbox message from `overlayInboxMessage`

Testing:
* Tested on Android Nexus5x and iOS iPhone.