### PR TITLE
Multiple webviews - re-attaching event listeners

### DIFF
--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -260,6 +260,11 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
 - (void)registerListener:(CDVInvokedUrlCommand *)command {
     self.listenerCallbackID = command.callbackId;
 
+    // Re-attach delegates
+    [UAirship push].pushNotificationDelegate = self;
+    [UAirship push].registrationDelegate = self;
+    [UAirship inbox].delegate = self;
+
     for (NSString *event in self.pendingEvents) {
         [self notifyListener:event data:self.pendingEvents[event]];
     }

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -139,7 +139,6 @@ document.addEventListener("deviceready", bindDocumentEvent, false)
  * @module UrbanAirship
  */
 module.exports = {
-  refresh: bindDocumentEvent,
 
   /**
    * Event fired when a new deep link is received.
@@ -183,6 +182,11 @@ module.exports = {
    * @param {object} extras Any push extras.
    * @param {number} [notification_id] The Android notification ID.
    */
+
+  /**
+   * Re-attaches document event listeners in this webview
+   */
+  reattach: bindDocumentEvent,
 
   /**
    * Enables or disables user notifications.

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -139,7 +139,7 @@ document.addEventListener("deviceready", bindDocumentEvent, false)
  * @module UrbanAirship
  */
 module.exports = {
-
+  refresh: bindDocumentEvent,
 
   /**
    * Event fired when a new deep link is received.

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -126,12 +126,14 @@ function TagGroupEditor(nativeMethod) {
     return editor
 }
 
-document.addEventListener("deviceready", function() {
+function bindDocumentEvent() {
     callNative(function(e) {
       console.log("Firing document event: " + e.eventType)
       cordova.fireDocumentEvent(e.eventType, e.eventData)
     }, null, "registerListener")
-}, false)
+}
+
+document.addEventListener("deviceready", bindDocumentEvent, false)
 
 /**
  * @module UrbanAirship


### PR DESCRIPTION
Hi UA team,

Thanks again for the recent `.dismiss()` features - that is going to let us take our deep-links to the next level :+1: 

I have a bit of a non-standard use case here, so I was hoping to get your input.

**Short version:**
Our app uses **multiple cordova webviews**, a "main" webview, and a secondary "child" webview that sometimes takes over.

Currently, **once the second child webview is dismissed, the main webview no longer receives UA document events.**

So, here are some small changes for your consideration. We're currently using them successfully.

-----

Long version:

In the `www/UrbanAirship.js` file, there is a call to the native `registerListener` method, which occurs once the cordova `deviceready` event fires.

This works great for any number of newly-created cordova webviews: the last webview "takes over" and receives the UA document events. However, once an upper webview is dismissed, the plugin cleans up, and no document events are fired in the older, underlying webview.

On Android, I was able to call `registerListener` manually, and "re-attach" the event listener when an old webview came back into active focus, like so:

```js
function reattach() {
  cordova.exec(function(e) {
    console.log("Firing document event: " + e.eventType)
    cordova.fireDocumentEvent(e.eventType, e.eventData)
  }, null, "UAirship", "registerListener")
}
```

However, this did not work on iOS, due to how the various delegates are attached to the UAirship SDK:

```objc
    // In "pluginInitialize" - attach delegates
    [UAirship push].pushNotificationDelegate = self;
    [UAirship push].registrationDelegate = self;
    [UAirship inbox].delegate = self;

    // in "dealloc" - clean up delegates
    [UAirship push].pushNotificationDelegate = nil;
    [UAirship push].registrationDelegate = nil;
    [UAirship inbox].delegate = nil;
```
The child webview cleaned everything up, leaving no delegates attached.

So, in the interest of making minimal changes, I added another "attach" process into the `registerListener` method. As a result, the delegates are attached _twice_ during the normal initialize/register process, but I assume that this is an inexpensive operation. The attach code could perhaps be removed from `pluginInitialize` to reduce duplication.

The second change is to export the `registerListener` exec call as a new `UAirship.reattach()` method, to be called by a re-focused webview.

-----

Thank you for your time -- I hope that these changes aren't too specific to our use-case! The changes are minor enough that managing our own fork would not be too painful, but I hope they can find a place in the official plugin :smile: 