### PR TITLE
[GH-206] Add workaround to AAPT2 issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Please visit http://support.urbanairship.com/ for any issues integrating or usin
 
 ### Quickstart
 
+Due to an [issue in the android resource processing (AAPT2)](https://issuetracker.google.com/issues/69347762),
+the GCM/FCM sender ID either needs to be prefixed with `sender:` or you can disable AAPT2 with
+[cordova-disable-aapt2](https://github.com/runtrizapps/cordova-android-disable-aapt2).
+
 1. Install this plugin using PhoneGap/Cordova CLI:
 
         cordova plugin add urbanairship-cordova
@@ -37,7 +41,7 @@ Please visit http://support.urbanairship.com/ for any issues integrating or usin
         <preference name="com.urbanairship.development_app_secret" value="Your Development App Secret" />
 
         <!-- Required for Android. -->
-        <preference name="com.urbanairship.gcm_sender" value="Your GCM Sender ID" />
+        <preference name="com.urbanairship.gcm_sender" value="sender:Your GCM Sender ID" />
 
         <!-- If the app is in production or not -->
         <preference name="com.urbanairship.in_production" value="true | false" />

--- a/jsdoc_readme.md
+++ b/jsdoc_readme.md
@@ -19,8 +19,8 @@
         <preference name="com.urbanairship.development_app_key" value="Your Development App Key" />
         <preference name="com.urbanairship.development_app_secret" value="Your Development App Secret" />
 
-        <!-- Required for Android. -->
-        <preference name="com.urbanairship.gcm_sender" value="Your GCM Sender ID" />
+        <!-- Required for Android. Make sure to prefix the sender ID with sender:-->
+        <preference name="com.urbanairship.gcm_sender" value="sender:Your GCM Sender ID" />
 
         <!-- If the app is in production or not -->
         <preference name="com.urbanairship.in_production" value="true | false" />


### PR DESCRIPTION
Adds a workaround for the AAPT2 bug. We now allow the sender ID to be prefixed with `sender:` so the android build system will not parse the number string. See https://issuetracker.google.com/issues/69347762 and https://github.com/urbanairship/phonegap-ua-push/issues/206 for more details