### PR TITLE
[MB-2531] Add response info to notification event

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -32,7 +32,7 @@
             </feature>
         </config-file>
 
-        <config-file parent="/*" target="AndroidManifest.xml">
+        <config-file parent="/manifest/application" target="AndroidManifest.xml">
             <meta-data
                 android:name="com.urbanairship.autopilot"
                 android:value="com.urbanairship.cordova.CordovaAutopilot"/>
@@ -123,7 +123,7 @@
             src="src/android/UAirshipPluginManager.java"
             target-dir="src/com/urbanairship/cordova"/>
         <source-file
-            src="src/android/events/ChannelEvent.java"
+            src="src/android/events/RegistrationEvent.java"
             target-dir="src/com/urbanairship/cordova/events"/>
         <source-file
             src="src/android/events/DeepLinkEvent.java"

--- a/src/android/CordovaAirshipReceiver.java
+++ b/src/android/CordovaAirshipReceiver.java
@@ -81,7 +81,7 @@ public class CordovaAirshipReceiver extends AirshipReceiver {
     protected boolean onNotificationOpened(@NonNull Context context, @NonNull NotificationInfo notificationInfo) {
         Log.i(TAG, "Notification opened. Alert: " + notificationInfo.getMessage().getAlert() + ". NotificationId: " + notificationInfo.getNotificationId());
 
-        UAirshipPluginManager.shared().notificationOpened(notificationInfo.getNotificationId(), notificationInfo.getMessage());
+        UAirshipPluginManager.shared().notificationOpened(notificationInfo);
 
         // Return false here to allow Urban Airship to auto launch the launcher activity
         return false;
@@ -91,7 +91,7 @@ public class CordovaAirshipReceiver extends AirshipReceiver {
     protected boolean onNotificationOpened(@NonNull Context context, @NonNull NotificationInfo notificationInfo, @NonNull ActionButtonInfo actionButtonInfo) {
         Log.i(TAG, "Notification action button opened. Button ID: " + actionButtonInfo.getButtonId() + ". NotificationId: " + notificationInfo.getNotificationId());
 
-        UAirshipPluginManager.shared().notificationOpened(notificationInfo.getNotificationId(), notificationInfo.getMessage());
+        UAirshipPluginManager.shared().notificationOpened(notificationInfo, actionButtonInfo);
 
         // Return false here to allow Urban Airship to auto launch the launcher
         // activity for foreground notification action buttons

--- a/src/android/UAirshipPluginManager.java
+++ b/src/android/UAirshipPluginManager.java
@@ -27,7 +27,10 @@ package com.urbanairship.cordova;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
+import com.urbanairship.AirshipReceiver;
 import com.urbanairship.UAirship;
 import com.urbanairship.cordova.events.RegistrationEvent;
 import com.urbanairship.cordova.events.DeepLinkEvent;
@@ -140,12 +143,23 @@ public class UAirshipPluginManager {
     /**
      * Called when the notification is opened.
      *
-     * @param notificationId The notification ID.
-     * @param pushMessage The push message.
+     * @param notificationInfo The notification info.
      */
-    void notificationOpened(int notificationId, PushMessage pushMessage) {
+    void notificationOpened(@NonNull AirshipReceiver.NotificationInfo notificationInfo) {
+        notificationOpened(new NotificationOpenedEvent(notificationInfo));
+    }
+
+    /**
+     * Called when the notification is opened.
+     *
+     * @param notificationInfo The notification info.
+     */
+    void notificationOpened(@NonNull AirshipReceiver.NotificationInfo notificationInfo, @Nullable AirshipReceiver.ActionButtonInfo actionButtonInfo) {
+        notificationOpened(new NotificationOpenedEvent(notificationInfo, actionButtonInfo));
+    }
+
+    private void notificationOpened(NotificationOpenedEvent event) {
         synchronized (shared) {
-            NotificationOpenedEvent event = new NotificationOpenedEvent(notificationId, pushMessage);
             this.notificationOpenedEvent = event;
 
             if (!notifyListener(event)) {

--- a/src/android/events/NotificationOpenedEvent.java
+++ b/src/android/events/NotificationOpenedEvent.java
@@ -25,6 +25,10 @@
 
 package com.urbanairship.cordova.events;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.urbanairship.AirshipReceiver;
 import com.urbanairship.Logger;
 import com.urbanairship.push.PushMessage;
 
@@ -41,17 +45,53 @@ public class NotificationOpenedEvent extends PushEvent {
 
     private static final String EVENT_NOTIFICATION_OPENED = "urbanairship.notification_opened";
 
-    private final PushMessage message;
-    private final Integer notificationId;
+    private static final String ACTION_ID = "actionID";
+    private static final String IS_FOREGROUND = "isForeground";
 
-    public NotificationOpenedEvent(Integer notificationId, PushMessage message) {
-        super(notificationId, message);
-        this.notificationId = notificationId;
-        this.message = message;
+    private final AirshipReceiver.ActionButtonInfo actionButtonInfo;
+
+
+    /**
+     * Creates an event for a notification response.
+     *
+     * @param notificationInfo The notification info.
+     */
+    public NotificationOpenedEvent(@NonNull AirshipReceiver.NotificationInfo notificationInfo) {
+        this(notificationInfo, null);
+    }
+
+    /**
+     * Creates an event for a notification action button response.
+     *
+     * @param notificationInfo The notification info.
+     * @param actionButtonInfo The action button info.
+     */
+    public NotificationOpenedEvent(@NonNull AirshipReceiver.NotificationInfo notificationInfo, @Nullable AirshipReceiver.ActionButtonInfo actionButtonInfo) {
+        super(notificationInfo.getNotificationId(), notificationInfo.getMessage());
+        this.actionButtonInfo = actionButtonInfo;
     }
 
     @Override
     public String getEventName() {
         return EVENT_NOTIFICATION_OPENED;
+    }
+
+
+    @Override
+    public JSONObject getEventData() {
+        JSONObject jsonObject = super.getEventData();
+
+        try {
+            if (actionButtonInfo != null) {
+                jsonObject.put(ACTION_ID, actionButtonInfo.getButtonId());
+                jsonObject.put(IS_FOREGROUND, actionButtonInfo.isForeground());
+            } else {
+                jsonObject.put(IS_FOREGROUND, true);
+            }
+        } catch (JSONException e) {
+            Logger.error("Error constructing notification object", e);
+        }
+
+        return jsonObject;
     }
 }

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -237,24 +237,22 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
 }
 
 /**
- * Helper method to perform a cordova command asynchronously.
+ * Helper method to perform a cordova command.
  *
  * @param command The cordova command.
  * @param block The UACordovaExecutionBlock to execute.
  */
 - (void)performCallbackWithCommand:(CDVInvokedUrlCommand *)command withBlock:(UACordovaExecutionBlock)block {
-    [self.commandDelegate runInBackground:^{
-        UACordovaCompletionHandler completionHandler = ^(CDVCommandStatus status, id value) {
-            CDVPluginResult *result = [self pluginResultForValue:value status:status];
-            [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
-        };
+    UACordovaCompletionHandler completionHandler = ^(CDVCommandStatus status, id value) {
+        CDVPluginResult *result = [self pluginResultForValue:value status:status];
+        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+    };
 
-        if (!block) {
-            completionHandler(CDVCommandStatus_OK, nil);
-        } else {
-            block(command.arguments, completionHandler);
-        }
-    }];
+    if (!block) {
+        completionHandler(CDVCommandStatus_OK, nil);
+    } else {
+        block(command.arguments, completionHandler);
+    }
 }
 
 #pragma mark Phonegap bridge
@@ -736,11 +734,11 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     optedIn = alertBool || badgeBool || soundBool;
 
     NSDictionary *eventBody = @{  @"optIn": @(optedIn),
-                             @"notificationOptions" : @{
-                                     NotificationPresentationAlertKey : @(alertBool),
-                                     NotificationPresentationBadgeKey : @(badgeBool),
-                                     NotificationPresentationSoundKey : @(soundBool) }
-                             };
+                                  @"notificationOptions" : @{
+                                          NotificationPresentationAlertKey : @(alertBool),
+                                          NotificationPresentationBadgeKey : @(badgeBool),
+                                          NotificationPresentationSoundKey : @(soundBool) }
+                                  };
 
     UA_LINFO(@"Opt in status changed.");
     [self notifyListener:EventNotificationOptInStatus data:eventBody];
@@ -759,7 +757,7 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
         [event setValue:@(YES) forKey:@"isForeground"];
     } else {
         UANotificationAction *notificationAction = [self notificationActionForCategory:notificationResponse.notificationContent.categoryIdentifier
-                                                                    actionIdentifier:notificationResponse.actionIdentifier];
+                                                                      actionIdentifier:notificationResponse.actionIdentifier];
 
         BOOL isForeground = notificationAction.options & UNNotificationActionOptionForeground;
         [event setValue:@(isForeground) forKey:@"isForeground"];
@@ -801,18 +799,14 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
 
 - (void)displayMessageCenter:(CDVInvokedUrlCommand *)command {
     [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [[UAirship defaultMessageCenter] display];
-        });
+        [[UAirship defaultMessageCenter] display];
         completionHandler(CDVCommandStatus_OK, nil);
     }];
 }
 
 - (void)dismissMessageCenter:(CDVInvokedUrlCommand *)command {
     [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [[UAirship defaultMessageCenter] dismiss];
-        });
+        [[UAirship defaultMessageCenter] dismiss];
         completionHandler(CDVCommandStatus_OK, nil);
     }];
 }
@@ -905,9 +899,7 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
         // Store a weak reference to the MessageViewController so we can dismiss it later
         self.messageViewController = mvc;
 
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navController animated:YES completion:nil];
-        });
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navController animated:YES completion:nil];
 
         completionHandler(CDVCommandStatus_OK, nil);
     }];
@@ -915,20 +907,15 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
 
 - (void)dismissInboxMessage:(CDVInvokedUrlCommand *)command {
     [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self.messageViewController dismissViewControllerAnimated:YES completion:nil];
-            self.messageViewController = nil;
-        });
-
+        [self.messageViewController dismissViewControllerAnimated:YES completion:nil];
+        self.messageViewController = nil;
         completionHandler(CDVCommandStatus_OK, nil);
     }];
 }
 
 - (void)dismissOverlayInboxMessage:(CDVInvokedUrlCommand *)command {
     [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [UALandingPageOverlayController closeAll:YES];
-        });
+        [UALandingPageOverlayController closeAll:YES];
         completionHandler(CDVCommandStatus_OK, nil);
     }];
 }
@@ -944,9 +931,7 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
             return;
         }
 
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [UALandingPageOverlayController showMessage:message];
-        });
+        [UALandingPageOverlayController showMessage:message];
 
         completionHandler(CDVCommandStatus_OK, nil);
     }];

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -182,6 +182,8 @@ module.exports = {
    * @param {string} message The push alert message.
    * @param {object} extras Any push extras.
    * @param {number} [notification_id] The Android notification ID.
+   * @param {string} [actionID] The ID of the notification action button if available.
+   * @param {boolean} isForeground Will always be true if the user taps the main notification. Otherwise its defined by the notificaiton action button.
    */
 
    /**


### PR DESCRIPTION
Adds notification response info to the open event.

I also fixed a few issues when I was testing. Lots of main thread checker warnings for iOS and build issues for Android. 

Testing:
 - Android registration event, notification opens, etc..
- iOS registration event. Still need to test a interactive notification.  