### PR TITLE
update getEventData to handle integer value

### DIFF
--- a/src/android/events/PushEvent.java
+++ b/src/android/events/PushEvent.java
@@ -67,6 +67,10 @@ public class PushEvent implements Event {
                 extras.put(key, Long.toString(message.getPushBundle().getLong(key)));
                 continue;
             }
+            if ("google.ttl".equals(key)) {
+                extras.put(key, Integer.toString(message.getPushBundle().getInt(key)));
+                continue;
+            }
             extras.put(key, message.getPushBundle().getString(key));
         }
 


### PR DESCRIPTION
Android's PushEvent is throwing an exception on `getEventData` while looping through `pushBundle`. We're passing `google.ttl` as an integer, but calling `getString` on it.

This gets the value as and integer and converts to a string before adding to `extras`.