### PR TITLE
Add Live Activity (iOS) and Live Update (Android) JS hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Version 19.0.0 - May 11, 2026
 
-Major release that migrates iOS to Swift Package Manager, drops CocoaPods support, and bumps the minimum Cordova platform versions.
+Major release that migrates iOS to Swift Package Manager, drops CocoaPods support, bumps the minimum Cordova platform versions, and adds Live Activity (iOS) and Live Update (Android) JS hooks.
 
 ### Changes
 - iOS now uses Swift Package Manager instead of CocoaPods. Requires `cordova-ios` 8.0.0 or newer.
 - Android now requires `cordova-android` 15.0.0 or newer.
+- Added `Airship.liveActivityManager` (iOS) with `list`, `listAll`, `start`, `update`, `end`, and `onLiveActivitiesUpdated` listener. Requires iOS 16.1+ and a host-app call to `LiveActivityManager.shared.setup` to register `ActivityAttributes` types.
+- Added `Airship.liveUpdateManager` (Android) with `list`, `listAll`, `start`, `update`, `end`, and `clearAll`.
 
 ## Version 18.2.0 - May 1, 2026
 

--- a/cordova-airship/src/android/AirshipCordova.kt
+++ b/cordova-airship/src/android/AirshipCordova.kt
@@ -11,6 +11,7 @@ import com.urbanairship.android.framework.proxy.events.EventEmitter
 import com.urbanairship.android.framework.proxy.events.EventType
 import com.urbanairship.android.framework.proxy.proxies.AirshipProxy
 import com.urbanairship.android.framework.proxy.proxies.FeatureFlagProxy
+import com.urbanairship.android.framework.proxy.proxies.LiveUpdateRequest
 import com.urbanairship.json.JsonList
 import com.urbanairship.json.JsonMap
 import com.urbanairship.json.JsonSerializable
@@ -290,6 +291,26 @@ class AirshipCordova : CordovaPlugin() {
                         val featureFlagProxy = FeatureFlagProxy(arg)
                         proxy.featureFlagManager.trackInteraction(flag = featureFlagProxy)
                     }
+                }
+
+                // Live Update
+                "liveUpdateManager#list" -> callback.resolve(scope, method) {
+                    proxy.liveUpdateManager.list(LiveUpdateRequest.List.fromJson(arg))
+                }
+                "liveUpdateManager#listAll" -> callback.resolve(scope, method) {
+                    proxy.liveUpdateManager.listAll()
+                }
+                "liveUpdateManager#start" -> callback.resolve(scope, method) {
+                    proxy.liveUpdateManager.start(LiveUpdateRequest.Start.fromJson(arg))
+                }
+                "liveUpdateManager#update" -> callback.resolve(scope, method) {
+                    proxy.liveUpdateManager.update(LiveUpdateRequest.Update.fromJson(arg))
+                }
+                "liveUpdateManager#end" -> callback.resolve(scope, method) {
+                    proxy.liveUpdateManager.end(LiveUpdateRequest.End.fromJson(arg))
+                }
+                "liveUpdateManager#clearAll" -> callback.resolve(scope, method) {
+                    proxy.liveUpdateManager.clearAll()
                 }
 
                 else -> callback.error("Not implemented")

--- a/cordova-airship/src/ios/AirshipCordova.swift
+++ b/cordova-airship/src/ios/AirshipCordova.swift
@@ -26,7 +26,8 @@ public final class AirshipCordova: CDVPlugin {
         .displayPreferenceCenter: "airship.event.display_preference_center",
         .notificationResponseReceived: "airship.event.notification_response",
         .pushReceived: "airship.event.push_received",
-        .notificationStatusChanged: "airship.event.notification_status_changed"
+        .notificationStatusChanged: "airship.event.notification_status_changed",
+        .liveActivitiesUpdated: "airship.event.ios_live_activities_updated"
     ]
 
     @MainActor
@@ -506,6 +507,53 @@ public final class AirshipCordova: CDVPlugin {
             )
 
             return nil
+
+        // Live Activity Manager
+        case "liveActivityManager#list":
+            if #available(iOS 16.1, *) {
+                return try await LiveActivityManager.shared.list(
+                    try command.requireCodableArg()
+                )
+            } else {
+                throw AirshipErrors.error("Live Activities only available on 16.1+")
+            }
+
+        case "liveActivityManager#listAll":
+            if #available(iOS 16.1, *) {
+                return try await LiveActivityManager.shared.listAll()
+            } else {
+                throw AirshipErrors.error("Live Activities only available on 16.1+")
+            }
+
+        case "liveActivityManager#start":
+            if #available(iOS 16.1, *) {
+                return try await LiveActivityManager.shared.start(
+                    try command.requireCodableArg()
+                )
+            } else {
+                throw AirshipErrors.error("Live Activities only available on 16.1+")
+            }
+
+        case "liveActivityManager#update":
+            if #available(iOS 16.1, *) {
+                try await LiveActivityManager.shared.update(
+                    try command.requireCodableArg()
+                )
+            } else {
+                throw AirshipErrors.error("Live Activities only available on 16.1+")
+            }
+            return nil
+
+        case "liveActivityManager#end":
+            if #available(iOS 16.1, *) {
+                try await LiveActivityManager.shared.end(
+                    try command.requireCodableArg()
+                )
+            } else {
+                throw AirshipErrors.error("Live Activities only available on 16.1+")
+            }
+            return nil
+
         default:
             throw AirshipErrors.error("Unavailable command \(method)")
         }

--- a/cordova-airship/types/index.d.ts
+++ b/cordova-airship/types/index.d.ts
@@ -177,6 +177,254 @@ export interface DisplayPreferenceCenterEvent {
 }
 
 /**
+ * Event fired when Live Activities are updated. iOS only.
+ */
+export interface LiveActivitiesUpdatedEvent {
+    /**
+     * The Live Activities.
+     */
+    activities: LiveActivity[];
+}
+
+/**
+ * Live Activity info. iOS only.
+ */
+export interface LiveActivity {
+    /**
+     * The activity ID.
+     */
+    id: string;
+    /**
+     * The attribute types.
+     */
+    attributeTypes: string;
+    /**
+     * The content.
+     */
+    content: LiveActivityContent;
+    /**
+     * The attributes.
+     */
+    attributes: JsonObject;
+}
+
+/**
+ * Live Activity content. iOS only.
+ */
+export interface LiveActivityContent {
+    /**
+     * The content state.
+     */
+    state: JsonObject;
+    /**
+     * Optional ISO 8601 date string that defines when the Live Activity will be stale.
+     */
+    staleDate?: string;
+    /**
+     * The relevance score.
+     */
+    relevanceScore: number;
+}
+
+/**
+ * Base Live Activity request. iOS only.
+ */
+export interface LiveActivityRequest {
+    /**
+     * Attributes type. This should match the Activity type of your Live Activity.
+     */
+    attributesType: string;
+}
+
+/**
+ * Live Activity list request. iOS only.
+ */
+export interface LiveActivityListRequest extends LiveActivityRequest {}
+
+/**
+ * Live Activity start request. iOS only.
+ */
+export interface LiveActivityStartRequest extends LiveActivityRequest {
+    /**
+     * Dynamic content.
+     */
+    content: LiveActivityContent;
+    /**
+     * Fixed attributes.
+     */
+    attributes: JsonObject;
+}
+
+/**
+ * Live Activity update request. iOS only.
+ */
+export interface LiveActivityUpdateRequest extends LiveActivityRequest {
+    /**
+     * The Live Activity ID to update.
+     */
+    activityId: string;
+    /**
+     * Dynamic content.
+     */
+    content: LiveActivityContent;
+}
+
+/**
+ * Live Activity end request. iOS only.
+ */
+export interface LiveActivityEndRequest extends LiveActivityRequest {
+    /**
+     * The Live Activity ID to end.
+     */
+    activityId: string;
+    /**
+     * Dynamic content.
+     */
+    content?: LiveActivityContent;
+    /**
+     * Dismissal policy. Defaults to `LiveActivityDismissalPolicyDefault`.
+     */
+    dismissalPolicy?: LiveActivityDismissalPolicy;
+}
+
+export type LiveActivityDismissalPolicy =
+    | LiveActivityDismissalPolicyImmediate
+    | LiveActivityDismissalPolicyDefault
+    | LiveActivityDismissalPolicyAfterDate;
+
+/**
+ * Dismissal policy to immediately dismiss the Live Activity on end.
+ */
+export interface LiveActivityDismissalPolicyImmediate {
+    type: 'immediate';
+}
+
+/**
+ * Dismissal policy to dismiss the Live Activity after the expiration.
+ */
+export interface LiveActivityDismissalPolicyDefault {
+    type: 'default';
+}
+
+/**
+ * Dismissal policy to dismiss the Live Activity after a given date.
+ */
+export interface LiveActivityDismissalPolicyAfterDate {
+    type: 'after';
+    /**
+     * ISO 8601 date string.
+     */
+    date: string;
+}
+
+/**
+ * Live Update info. Android only.
+ */
+export interface LiveUpdate {
+    /**
+     * The Live Update name.
+     */
+    name: string;
+    /**
+     * The Live Update type.
+     */
+    type: string;
+    /**
+     * Dynamic content.
+     */
+    content: JsonObject;
+    /**
+     * ISO 8601 date string of the last content update.
+     */
+    lastContentUpdateTimestamp: string;
+    /**
+     * ISO 8601 date string of the last state update.
+     */
+    lastStateChangeTimestamp: string;
+    /**
+     * Optional ISO 8601 date string that defines when to end this Live Update.
+     */
+    dismissTimestamp?: string;
+}
+
+/**
+ * Live Update list request. Android only.
+ */
+export interface LiveUpdateListRequest {
+    type: string;
+}
+
+/**
+ * Live Update start request. Android only.
+ */
+export interface LiveUpdateStartRequest {
+    /**
+     * The Live Update name.
+     */
+    name: string;
+    /**
+     * The Live Update type.
+     */
+    type: string;
+    /**
+     * Dynamic content.
+     */
+    content: JsonObject;
+    /**
+     * Optional ISO 8601 date string, used to filter out of order updates.
+     */
+    timestamp?: string;
+    /**
+     * Optional ISO 8601 date string that defines when to end this Live Update.
+     */
+    dismissTimestamp?: string;
+}
+
+/**
+ * Live Update update request. Android only.
+ */
+export interface LiveUpdateUpdateRequest {
+    /**
+     * The Live Update name.
+     */
+    name: string;
+    /**
+     * Dynamic content.
+     */
+    content: JsonObject;
+    /**
+     * Optional ISO 8601 date string, used to filter out of order updates.
+     */
+    timestamp?: string;
+    /**
+     * Optional ISO 8601 date string that defines when to end this Live Update.
+     */
+    dismissTimestamp?: string;
+}
+
+/**
+ * Live Update end request. Android only.
+ */
+export interface LiveUpdateEndRequest {
+    /**
+     * The Live Update name.
+     */
+    name: string;
+    /**
+     * Dynamic content.
+     */
+    content?: JsonObject;
+    /**
+     * Optional ISO 8601 date string, used to filter out of order updates.
+     */
+    timestamp?: string;
+    /**
+     * Optional ISO 8601 date string that defines when to end this Live Update.
+     */
+    dismissTimestamp?: string;
+}
+
+/**
  * iOS options
  */
 export namespace iOS {
@@ -1954,6 +2202,154 @@ export interface AirshipActions {
     ): void
 }
 
+/**
+ * Live Activity manager. iOS only.
+ */
+export interface AirshipLiveActivityManager {
+
+    /**
+     * Lists any Live Activities for the request.
+     * @param request The request options.
+     * @param success Success callback with the list.
+     * @param error Error callback.
+     */
+    list(
+        request: LiveActivityListRequest,
+        success: (activities: LiveActivity[]) => void,
+        error?: (err: string) => void
+    ): void
+
+    /**
+     * Lists all Live Activities.
+     * @param success Success callback with the list.
+     * @param error Error callback.
+     */
+    listAll(
+        success: (activities: LiveActivity[]) => void,
+        error?: (err: string) => void
+    ): void
+
+    /**
+     * Starts a Live Activity.
+     * @param request The request options.
+     * @param success Success callback with the started activity.
+     * @param error Error callback.
+     */
+    start(
+        request: LiveActivityStartRequest,
+        success: (activity: LiveActivity) => void,
+        error?: (err: string) => void
+    ): void
+
+    /**
+     * Updates a Live Activity.
+     * @param request The request options.
+     * @param success Success callback.
+     * @param error Error callback.
+     */
+    update(
+        request: LiveActivityUpdateRequest,
+        success?: () => void,
+        error?: (err: string) => void
+    ): void
+
+    /**
+     * Ends a Live Activity.
+     * @param request The request options.
+     * @param success Success callback.
+     * @param error Error callback.
+     */
+    end(
+        request: LiveActivityEndRequest,
+        success?: () => void,
+        error?: (err: string) => void
+    ): void
+
+    /**
+     * Live Activities updated listener.
+     *
+     * @param callback The callback.
+     * @return A cancellable that can be used to cancel the listener.
+     */
+    onLiveActivitiesUpdated(
+        callback: (event: LiveActivitiesUpdatedEvent) => void
+    ): Cancellable
+}
+
+/**
+ * Live Update manager. Android only.
+ */
+export interface AirshipLiveUpdateManager {
+
+    /**
+     * Lists any Live Updates for the request.
+     * @param request The request options.
+     * @param success Success callback with the list.
+     * @param error Error callback.
+     */
+    list(
+        request: LiveUpdateListRequest,
+        success: (updates: LiveUpdate[]) => void,
+        error?: (err: string) => void
+    ): void
+
+    /**
+     * Lists all Live Updates.
+     * @param success Success callback with the list.
+     * @param error Error callback.
+     */
+    listAll(
+        success: (updates: LiveUpdate[]) => void,
+        error?: (err: string) => void
+    ): void
+
+    /**
+     * Starts a Live Update.
+     * @param request The request options.
+     * @param success Success callback.
+     * @param error Error callback.
+     */
+    start(
+        request: LiveUpdateStartRequest,
+        success?: () => void,
+        error?: (err: string) => void
+    ): void
+
+    /**
+     * Updates a Live Update.
+     * @param request The request options.
+     * @param success Success callback.
+     * @param error Error callback.
+     */
+    update(
+        request: LiveUpdateUpdateRequest,
+        success?: () => void,
+        error?: (err: string) => void
+    ): void
+
+    /**
+     * Ends a Live Update.
+     * @param request The request options.
+     * @param success Success callback.
+     * @param error Error callback.
+     */
+    end(
+        request: LiveUpdateEndRequest,
+        success?: () => void,
+        error?: (err: string) => void
+    ): void
+
+    /**
+     * Clears all Live Updates.
+     * @param success Success callback.
+     * @param error Error callback.
+     */
+    clearAll(
+        success?: () => void,
+        error?: (err: string) => void
+    ): void
+}
+
 export interface Airship {
     readonly actions: AirshipActions;
     readonly analytics: AirshipAnalytics;
@@ -1966,6 +2362,8 @@ export interface Airship {
     readonly privacyManager: AirshipPrivacyManager;
     readonly push: AirshipPush;
     readonly featureFlagManager: AirshipFeatureFlagManager;
+    readonly liveActivityManager: AirshipLiveActivityManager;
+    readonly liveUpdateManager: AirshipLiveUpdateManager;
 
     /**
      * Calls takeOff. If Airship is already configured for

--- a/cordova-airship/www/Airship.js
+++ b/cordova-airship/www/Airship.js
@@ -17,7 +17,9 @@ var cordova = require("cordova"),
         },
         privacyManager: {},
         actions: {},
-        inApp: {}
+        inApp: {},
+        liveActivityManager: {},
+        liveUpdateManager: {}
     }
 
 // Argcheck values:
@@ -694,6 +696,70 @@ airship.locale.clearLocaleOverride = function (success, failure) {
 airship.locale.getLocale = function (success, failure) {
     argscheck.checkArgs('fF', 'Airship.locale.getLocale', arguments)
     perform("locale#getLocale", null, success, failure)
+}
+
+// Live Activity Manager (iOS)
+
+airship.liveActivityManager.list = function (request, success, failure) {
+    argscheck.checkArgs('ofF', 'Airship.liveActivityManager.list', arguments)
+    perform("liveActivityManager#list", request, success, failure)
+}
+
+airship.liveActivityManager.listAll = function (success, failure) {
+    argscheck.checkArgs('fF', 'Airship.liveActivityManager.listAll', arguments)
+    perform("liveActivityManager#listAll", null, success, failure)
+}
+
+airship.liveActivityManager.start = function (request, success, failure) {
+    argscheck.checkArgs('ofF', 'Airship.liveActivityManager.start', arguments)
+    perform("liveActivityManager#start", request, success, failure)
+}
+
+airship.liveActivityManager.update = function (request, success, failure) {
+    argscheck.checkArgs('oFF', 'Airship.liveActivityManager.update', arguments)
+    perform("liveActivityManager#update", request, success, failure)
+}
+
+airship.liveActivityManager.end = function (request, success, failure) {
+    argscheck.checkArgs('oFF', 'Airship.liveActivityManager.end', arguments)
+    perform("liveActivityManager#end", request, success, failure)
+}
+
+airship.liveActivityManager.onLiveActivitiesUpdated = function (callback) {
+    argscheck.checkArgs('F', 'Airship.liveActivityManager.onLiveActivitiesUpdated', arguments)
+    return registerListener("airship.event.ios_live_activities_updated", callback)
+}
+
+// Live Update Manager (Android)
+
+airship.liveUpdateManager.list = function (request, success, failure) {
+    argscheck.checkArgs('ofF', 'Airship.liveUpdateManager.list', arguments)
+    perform("liveUpdateManager#list", request, success, failure)
+}
+
+airship.liveUpdateManager.listAll = function (success, failure) {
+    argscheck.checkArgs('fF', 'Airship.liveUpdateManager.listAll', arguments)
+    perform("liveUpdateManager#listAll", null, success, failure)
+}
+
+airship.liveUpdateManager.start = function (request, success, failure) {
+    argscheck.checkArgs('oFF', 'Airship.liveUpdateManager.start', arguments)
+    perform("liveUpdateManager#start", request, success, failure)
+}
+
+airship.liveUpdateManager.update = function (request, success, failure) {
+    argscheck.checkArgs('oFF', 'Airship.liveUpdateManager.update', arguments)
+    perform("liveUpdateManager#update", request, success, failure)
+}
+
+airship.liveUpdateManager.end = function (request, success, failure) {
+    argscheck.checkArgs('oFF', 'Airship.liveUpdateManager.end', arguments)
+    perform("liveUpdateManager#end", request, success, failure)
+}
+
+airship.liveUpdateManager.clearAll = function (success, failure) {
+    argscheck.checkArgs('FF', 'Airship.liveUpdateManager.clearAll', arguments)
+    perform("liveUpdateManager#clearAll", null, success, failure)
 }
 
 module.exports = airship;


### PR DESCRIPTION
## Summary

- Add `airship.liveActivityManager` (iOS) — `list`, `listAll`, `start`, `update`, `end`, and `onLiveActivitiesUpdated` listener.
- Add `airship.liveUpdateManager` (Android) — `list`, `listAll`, `start`, `update`, `end`, `clearAll`.
- Wire native dispatch to `LiveActivityManager.shared` (iOS 16.1+) and `AirshipProxy.liveUpdateManager` (Android), matching the API surface of `capacitor-airship`.
- Forward `LiveActivitiesUpdatedEvent` through a new `airship.event.ios_live_activities_updated` listener.

## Notes

- JS API uses cordova's `(request, success, failure)` callback style (capacitor uses Promises) — matches every other manager in `www/Airship.js`.
- Live Activities is iOS-only and Live Updates is Android-only; both match the platform split in `capacitor-airship`.
- Host iOS apps must still call `LiveActivityManager.shared.setup { ... }` at launch to register their `ActivityAttributes` types — same requirement as capacitor. Worth a README/MIGRATION note in a follow-up.

## Test plan

- [ ] Build the cordova example app on iOS 16.1+ and exercise `start` → `update` → `end` round trip against a registered `ActivityAttributes` type.
- [ ] Verify `onLiveActivitiesUpdated` fires when a Live Activity starts and when its content updates.
- [ ] Build on Android and exercise `liveUpdateManager` round trip against a registered Live Update handler.
- [ ] Confirm TypeScript consumers see the new manager types on `Airship`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)