### PR TITLE
Release 19.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Cordova Plugin Changelog
 
+## Version 19.1.0 - July 23, 2026
+
+Minor release that updates the Android SDK to 20.10.0 and the iOS SDK to 20.11.0.
+
+### Changes
+- Updated Android SDK to [20.10.0](https://github.com/urbanairship/android-library/releases/tag/20.10.0)
+- Updated iOS SDK to [20.11.0](https://github.com/urbanairship/ios-library/releases/tag/20.11.0)
+
+
 ## Version 19.0.1 - June 12, 2026
 
 Patch release that updates the Android SDK to 20.7.4 and the iOS SDK to 20.7.2

--- a/cordova-airship-hms/package-lock.json
+++ b/cordova-airship-hms/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ua/cordova-airship-hms",
-  "version": "19.0.1",
+  "version": "19.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ua/cordova-airship-hms",
-      "version": "19.0.1",
+      "version": "19.1.0",
       "engines": [
         {
           "name": "cordova-android",

--- a/cordova-airship-hms/package.json
+++ b/cordova-airship-hms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/cordova-airship-hms",
-  "version": "19.0.1",
+  "version": "19.1.0",
   "description": "Airship HMS Cordova plugin",
   "cordova": {
     "id": "@ua/cordova-airship-hms",

--- a/cordova-airship-hms/plugin.xml
+++ b/cordova-airship-hms/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="@ua/cordova-airship-hms" version="19.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="@ua/cordova-airship-hms" version="19.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     
     <name>Airship HMS</name>
     <description>Airship HMS Cordova plugin</description>
@@ -12,7 +12,7 @@
         <engine name="cordova" version=">=12.0.0"/>
     </engines>
 
-    <dependency id="@ua/cordova-airship" version="19.0.1"/>
+    <dependency id="@ua/cordova-airship" version="19.1.0"/>
 
     <!-- android -->
     <platform name="android">

--- a/cordova-airship-hms/src/android/build-extras.gradle
+++ b/cordova-airship-hms/src/android/build-extras.gradle
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    implementation "com.urbanairship.android:airship-framework-proxy-hms:15.9.1"
+    implementation "com.urbanairship.android:airship-framework-proxy-hms:15.13.0"
     implementation 'com.huawei.hms:push:6.13.0.300'
 }

--- a/cordova-airship/package-lock.json
+++ b/cordova-airship/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ua/cordova-airship",
-  "version": "19.0.1",
+  "version": "19.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ua/cordova-airship",
-      "version": "19.0.1",
+      "version": "19.1.0",
       "engines": [
         {
           "name": "cordova-android",

--- a/cordova-airship/package.json
+++ b/cordova-airship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/cordova-airship",
-  "version": "19.0.1",
+  "version": "19.1.0",
   "description": "Airship Cordova plugin",
   "cordova": {
     "id": "@ua/cordova-airship",

--- a/cordova-airship/plugin.xml
+++ b/cordova-airship/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin id="@ua/cordova-airship" version="19.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="@ua/cordova-airship" version="19.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     
     <name>Airship</name>
     <description>Airship Cordova plugin</description>

--- a/cordova-airship/src/android/AirshipCordovaVersion.kt
+++ b/cordova-airship/src/android/AirshipCordovaVersion.kt
@@ -3,5 +3,5 @@
 package com.urbanairship.cordova
 
 object AirshipCordovaVersion {
-    var version = "19.0.1"
+    var version = "19.1.0"
 }

--- a/cordova-airship/src/android/build-extras.gradle
+++ b/cordova-airship/src/android/build-extras.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    api "com.urbanairship.android:airship-framework-proxy:15.9.1"
+    api "com.urbanairship.android:airship-framework-proxy:15.13.0"
 }

--- a/cordova-airship/src/ios/AirshipCordovaVersion.swift
+++ b/cordova-airship/src/ios/AirshipCordovaVersion.swift
@@ -3,5 +3,5 @@
 import Foundation
 
 class AirshipCordovaVersion {
-    static let version = "19.0.1"
+    static let version = "19.1.0"
 }


### PR DESCRIPTION
Minor release preparation for Cordova v19.1.0

## Version Updates
- Plugin: 19.1.0
- Framework Proxy: 15.13.0
- iOS SDK: 20.11.0
- Android SDK: 20.10.0

## Changed Files
```
CHANGELOG.md
cordova-airship-hms/package-lock.json
cordova-airship-hms/package.json
cordova-airship-hms/plugin.xml
cordova-airship-hms/src/android/build-extras.gradle
cordova-airship/package-lock.json
cordova-airship/package.json
cordova-airship/plugin.xml
cordova-airship/src/android/AirshipCordovaVersion.kt
cordova-airship/src/android/build-extras.gradle
cordova-airship/src/ios/AirshipCordovaVersion.swift
```

## Next Steps
1. Review version updates
2. Verify changelog accuracy
3. Merge when ready